### PR TITLE
Add pydocstyle linter

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,6 +31,10 @@ jobs:
         run: |
           poetry run pylint --errors-only blackboxopt/
           poetry run pylint --errors-only tests/
+      - name: DocStyle Linting
+        continue-on-error: true
+        if: always()
+        run: poetry run pydocstyle
       - name: Run tests
         if: always()
         run: poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -612,6 +612,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydocstyle"
+version = "6.1.1"
+description = "Python docstring style checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+snowballstemmer = "*"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "pygments"
 version = "2.9.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -795,6 +809,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "snowballstemmer"
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "sortedcontainers"
 version = "2.4.0"
 description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
@@ -944,7 +966,7 @@ visualization = ["plotly", "scipy", "pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "3d91a0ad7917d2c6420a36a31b62709fccad404d0037e75764cbab1fecb409cc"
+content-hash = "3c61e65470c4f1a64bc16850f5ff1eb190c6e6eb8781abdbe1ce57213838c5e6"
 
 [metadata.files]
 appdirs = [
@@ -1359,6 +1381,10 @@ py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
+pydocstyle = [
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
+]
 pygments = [
     {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
     {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
@@ -1504,6 +1530,10 @@ scipy = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+snowballstemmer = [
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ mkdocs-gen-files = "^0.3.1"
 mkdocs-awesome-pages-plugin = "^2.5.0"
 mike = "^1.0.1"
 pylint = "^2.8.2"
+pydocstyle = "^6.1.1"
 
 [tool.poetry.extras]
 all = ["numpy", "plotly", "scipy", "statsmodels", "dask", "distributed", "pandas"]
@@ -84,6 +85,12 @@ disable = [
     "too-few-public-methods",
     "too-many-function-args"
 ]
+
+[tool.pydocstyle]
+convention = "google"
+add-ignore = "D105"
+match = '(?!test_|__init__).*\.py'
+match-dir = '[^\tests].*'
 
 [tool.coverage.run]
 source = ['blackboxopt']


### PR DESCRIPTION
Adds [pydocstyle](https://github.com/PyCQA/pydocstyle) for linting google-styled docs. Check is added to gh action, but with the "continue-on-error" switch, as we have to fix quite a bunch of issues first (and/or adjust the linter config).

Hints:
- Contributors using `vscode` can easily enable issue-highlighting by enabling `python.linting.pydocstyleEnabled` in the settings UI.
- In CLI just run `pydocstyle` (or `pydocstyle --explain` for more details)

Signed-off-by: Buech Holger <holger.buech@de.bosch.com>