### PR TITLE
Switch to report evaluations in batches

### DIFF
--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -104,14 +104,14 @@ class Optimizer(abc.ABC):
         """
 
     @abc.abstractmethod
-    def report_evaluation(self, evaluation: Evaluation) -> None:
-        """Report an evaluated evaluation specification.
+    def report_evaluations(self, evaluations: Iterable[Evaluation]) -> None:
+        """Report multiple evaluated evaluation specifications.
 
         NOTE: Not all optimizers support reporting results for evaluation specifications
         that were not proposed by the optimizer.
 
         Args:
-            evaluation: An evaluated evaluation specification.
+            evaluations: An iterable of evaluated evaluation specifications.
         """
 
 
@@ -133,14 +133,14 @@ class SingleObjectiveOptimizer(Optimizer):
         super().__init__(search_space=search_space, seed=seed)
         self.objective = objective
 
-    def report_evaluation(self, evaluation: Evaluation) -> None:
-        raise_on_unknown_or_incomplete(
-            exception=ObjectivesError,
-            known=[self.objective.name],
-            reported=evaluation.objectives.keys(),
-        )
-
-        super().report_evaluation(evaluation)
+    def report_evaluations(self, evaluations: Iterable[Evaluation]) -> None:
+        for evaluation in evaluations:
+            raise_on_unknown_or_incomplete(
+                exception=ObjectivesError,
+                known=[self.objective.name],
+                reported=evaluation.objectives.keys(),
+            )
+        super().report_evaluations(evaluations)
 
 
 class MultiObjectiveOptimizer(Optimizer):
@@ -163,11 +163,12 @@ class MultiObjectiveOptimizer(Optimizer):
         _raise_on_duplicate_objective_names(objectives)
         self.objectives = objectives
 
-    def report_evaluation(self, evaluation: Evaluation) -> None:
-        raise_on_unknown_or_incomplete(
-            exception=ObjectivesError,
-            known=[o.name for o in self.objectives],
-            reported=evaluation.objectives.keys(),
-        )
+    def report_evaluations(self, evaluations: Iterable[Evaluation]) -> None:
+        for evaluation in evaluations:
+            raise_on_unknown_or_incomplete(
+                exception=ObjectivesError,
+                known=[o.name for o in self.objectives],
+                reported=evaluation.objectives.keys(),
+            )
 
-        super().report_evaluation(evaluation)
+        super().report_evaluations(evaluations)

--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -105,9 +105,7 @@ class Optimizer(abc.ABC):
         """
 
     @abc.abstractmethod
-    def report_evaluations(
-        self, evaluations: Union[Evaluation, Iterable[Evaluation]]
-    ) -> None:
+    def report(self, evaluations: Union[Evaluation, Iterable[Evaluation]]) -> None:
         """Report one or more evaluated evaluation specifications.
 
         NOTE: Not all optimizers support reporting results for evaluation specifications
@@ -137,9 +135,7 @@ class SingleObjectiveOptimizer(Optimizer):
         super().__init__(search_space=search_space, seed=seed)
         self.objective = objective
 
-    def report_evaluations(
-        self, evaluations: Union[Evaluation, Iterable[Evaluation]]
-    ) -> None:
+    def report(self, evaluations: Union[Evaluation, Iterable[Evaluation]]) -> None:
         if isinstance(evaluations, Evaluation):
             evaluations = [evaluations]
 
@@ -150,7 +146,7 @@ class SingleObjectiveOptimizer(Optimizer):
                 reported=evaluation.objectives.keys(),
             )
 
-        super().report_evaluations(evaluations)
+        super().report(evaluations)
 
 
 class MultiObjectiveOptimizer(Optimizer):
@@ -173,9 +169,7 @@ class MultiObjectiveOptimizer(Optimizer):
         _raise_on_duplicate_objective_names(objectives)
         self.objectives = objectives
 
-    def report_evaluations(
-        self, evaluations: Union[Evaluation, Iterable[Evaluation]]
-    ) -> None:
+    def report(self, evaluations: Union[Evaluation, Iterable[Evaluation]]) -> None:
         if isinstance(evaluations, Evaluation):
             evaluations = [evaluations]
 
@@ -186,4 +180,4 @@ class MultiObjectiveOptimizer(Optimizer):
                 reported=evaluation.objectives.keys(),
             )
 
-        super().report_evaluations(evaluations)
+        super().report(evaluations)

--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -5,7 +5,6 @@
 
 import abc
 import collections
-from collections.abc import Iterable as abc_Iterable
 from dataclasses import dataclass
 from typing import Iterable, List, Type, Union
 
@@ -36,6 +35,17 @@ class ConstraintsError(ValueError):
 
 class ContextError(ValueError):
     """Raised on incomplete or missing context information."""
+
+
+class EvaluationsError(ValueError):
+    """Raised on invalid evaluations.
+
+    The problematic evaluations are passed in the `evaluations` attribute.
+    """
+
+    def __init__(self, message: str, evaluations: List[Evaluation]):
+        self.message = message
+        self.evaluations = evaluations
 
 
 @dataclass

--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -40,7 +40,8 @@ class ContextError(ValueError):
 class EvaluationsError(ValueError):
     """Raised on invalid evaluations.
 
-    The problematic evaluations are passed in the `evaluations` attribute.
+    The problematic evaluations and their respective exceptions are passed in the
+    `evaluations_with_errors` attribute.
     """
 
     def __init__(self, evaluations_with_errors: List[Tuple[Evaluation, Exception]]):
@@ -149,6 +150,20 @@ class SingleObjectiveOptimizer(Optimizer):
         self.objective = objective
 
     def report(self, evaluations: Union[Evaluation, Iterable[Evaluation]]) -> None:
+        """Report one or multiple evaluations to the optimizer.
+
+        All valid evaluations are processed. Faulty evaluations are not processed,
+        instead an `EvaluationsError` is raised, which includes the problematic
+        evaluations with their respective Exceptions in the `evaluations_with_errors`
+        attribute.
+
+        Args:
+            evaluations: A single evaluated evaluation specifications, or an iterable
+            of many.
+
+        Raises:
+            EvaluationsError: Raised when an evaluation could not be processed.
+        """
         if isinstance(evaluations, Evaluation):
             evaluations = [evaluations]
 

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -162,13 +162,13 @@ def run_optimization_loop(
                 logger.info("Optimization is complete")
                 break
 
-        for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report(evaluation)
-            evaluations.append(evaluation)
+        new_evaluation = dask_scheduler.check_for_results(timeout_s=20)
+        optimizer.report(new_evaluation)
+        evaluations.extend(new_evaluation)
 
     while dask_scheduler.has_running_jobs():
-        for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report(evaluation)
-            evaluations.append(evaluation)
+        new_evaluation = dask_scheduler.check_for_results(timeout_s=20)
+        optimizer.report(new_evaluation)
+        evaluations.extend(new_evaluation)
 
     return evaluations

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -163,12 +163,12 @@ def run_optimization_loop(
                 break
 
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluations(evaluation)
+            optimizer.report(evaluation)
             evaluations.append(evaluation)
 
     while dask_scheduler.has_running_jobs():
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluations(evaluation)
+            optimizer.report(evaluation)
             evaluations.append(evaluation)
 
     return evaluations

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -163,12 +163,12 @@ def run_optimization_loop(
                 break
 
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluation(evaluation)
+            optimizer.report_evaluations([evaluation])
             evaluations.append(evaluation)
 
     while dask_scheduler.has_running_jobs():
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluation(evaluation)
+            optimizer.report_evaluations([evaluation])
             evaluations.append(evaluation)
 
     return evaluations

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -163,12 +163,12 @@ def run_optimization_loop(
                 break
 
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluations([evaluation])
+            optimizer.report_evaluations(evaluation)
             evaluations.append(evaluation)
 
     while dask_scheduler.has_running_jobs():
         for evaluation in dask_scheduler.check_for_results(timeout_s=20):
-            optimizer.report_evaluations([evaluation])
+            optimizer.report_evaluations(evaluation)
             evaluations.append(evaluation)
 
     return evaluations

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -162,13 +162,13 @@ def run_optimization_loop(
                 logger.info("Optimization is complete")
                 break
 
-        new_evaluation = dask_scheduler.check_for_results(timeout_s=20)
-        optimizer.report(new_evaluation)
-        evaluations.extend(new_evaluation)
+        new_evaluations = dask_scheduler.check_for_results(timeout_s=20)
+        optimizer.report(new_evaluations)
+        evaluations.extend(new_evaluations)
 
     while dask_scheduler.has_running_jobs():
-        new_evaluation = dask_scheduler.check_for_results(timeout_s=20)
-        optimizer.report(new_evaluation)
-        evaluations.extend(new_evaluation)
+        new_evaluations = dask_scheduler.check_for_results(timeout_s=20)
+        optimizer.report(new_evaluations)
+        evaluations.extend(new_evaluations)
 
     return evaluations

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -78,7 +78,7 @@ def run_optimization_loop(
                 logger=logger,
                 objectives=objectives,
             )
-            optimizer.report_evaluations(evaluation)
+            optimizer.report(evaluation)
             evaluations.append(evaluation)
             logger.debug(f"Result: {evaluation}")
 

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -78,7 +78,7 @@ def run_optimization_loop(
                 logger=logger,
                 objectives=objectives,
             )
-            optimizer.report_evaluations([evaluation])
+            optimizer.report_evaluations(evaluation)
             evaluations.append(evaluation)
             logger.debug(f"Result: {evaluation}")
 

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -78,7 +78,7 @@ def run_optimization_loop(
                 logger=logger,
                 objectives=objectives,
             )
-            optimizer.report_evaluation(evaluation)
+            optimizer.report_evaluations([evaluation])
             evaluations.append(evaluation)
             logger.debug(f"Result: {evaluation}")
 

--- a/blackboxopt/optimizers/staged/optimizer.py
+++ b/blackboxopt/optimizers/staged/optimizer.py
@@ -47,10 +47,8 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         self.evaluation_uuid_to_iteration: Dict[str, int] = {}
         self.pending_configurations: Dict[str, EvaluationSpecification] = {}
 
-    def report_evaluations(
-        self, evaluations: Union[Evaluation, Iterable[Evaluation]]
-    ) -> None:
-        super().report_evaluations(evaluations)
+    def report(self, evaluations: Union[Evaluation, Iterable[Evaluation]]) -> None:
+        super().report(evaluations)
 
         if isinstance(evaluations, Evaluation):
             evaluations = [evaluations]

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -73,7 +73,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         )
     else:
         evaluation = eval_spec.create_evaluation(objectives={"loss": None})
-    optimizer.report_evaluations([evaluation])
+    optimizer.report_evaluations(evaluation)
 
     for _ in range(n_max_evaluations):
 
@@ -89,7 +89,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
             evaluation_result = {"loss": loss}
 
         evaluation = eval_spec.create_evaluation(objectives=evaluation_result)
-        optimizer.report_evaluations([evaluation])
+        optimizer.report_evaluations(evaluation)
 
     return True
 
@@ -145,7 +145,7 @@ def raises_objectives_error_when_reporting_unknown_objective(
 
     try:
         evaluation = es.create_evaluation(objectives={"unknown_objective": 0})
-        opt.report_evaluations([evaluation])
+        opt.report_evaluations(evaluation)
 
         raise AssertionError(
             f"Optimizer {optimizer_class} did not raise an ObjectivesError when a "

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -73,7 +73,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         )
     else:
         evaluation = eval_spec.create_evaluation(objectives={"loss": None})
-    optimizer.report_evaluations(evaluation)
+    optimizer.report(evaluation)
 
     for _ in range(n_max_evaluations):
 
@@ -89,7 +89,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
             evaluation_result = {"loss": loss}
 
         evaluation = eval_spec.create_evaluation(objectives=evaluation_result)
-        optimizer.report_evaluations(evaluation)
+        optimizer.report(evaluation)
 
     return True
 
@@ -123,7 +123,7 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
 
         es1 = opt.get_evaluation_specification()
         evaluation1 = es1.create_evaluation(objectives={"loss": 0.42})
-        opt.report_evaluations([evaluation1])
+        opt.report([evaluation1])
         es2 = opt.get_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
@@ -145,7 +145,7 @@ def raises_objectives_error_when_reporting_unknown_objective(
 
     try:
         evaluation = es.create_evaluation(objectives={"unknown_objective": 0})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
         raise AssertionError(
             f"Optimizer {optimizer_class} did not raise an ObjectivesError when a "

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -123,12 +123,45 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
 
         es1 = opt.get_evaluation_specification()
         evaluation1 = es1.create_evaluation(objectives={"loss": 0.42})
-        opt.report([evaluation1])
+        opt.report(evaluation1)
         es2 = opt.get_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
 
     assert final_configurations[0] == final_configurations[1]
+    return True
+
+
+def handles_reporting_evaluations_list(optimizer_class, optimizer_kwargs: dict) -> bool:
+    """Check if optimizer's report method can process an iterable of evalutions.
+
+    All optimizers should be able to allow reporting batches of evalutions. It's up to
+    the optimizer's implementation, if evaluations in a batch are processed
+    one by one like if they were reported individually, or if a batch is handled
+    differently.
+
+    Args:
+        optimizer_class: Optimizer to test.
+        optimizer_kwargs: Expected to contain additional arguments for initializating
+            the optimizer. (`search_space` and `objective(s)` are set automatically
+            by the test.)
+
+    Returns:
+        `True` if the test is passed.
+    """
+    opt = _initialize_optimizer(
+        optimizer_class,
+        optimizer_kwargs,
+        objective=Objective("loss", False),
+        objectives=[Objective("loss", False)],
+    )
+    evaluations = []
+    for _ in range(3):
+        es = opt.get_evaluation_specification()
+        evaluation = es.create_evaluation(objectives={"loss": 0.42})
+        evaluations.append(evaluation)
+
+    opt.report(evaluations)
     return True
 
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -68,13 +68,12 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     eval_spec = optimizer.get_evaluation_specification()
 
     if issubclass(optimizer_class, MultiObjectiveOptimizer):
-        optimizer.report_evaluation(
-            eval_spec.create_evaluation(objectives={"loss": None, "score": None})
+        evaluation = eval_spec.create_evaluation(
+            objectives={"loss": None, "score": None}
         )
     else:
-        optimizer.report_evaluation(
-            eval_spec.create_evaluation(objectives={"loss": None})
-        )
+        evaluation = eval_spec.create_evaluation(objectives={"loss": None})
+    optimizer.report_evaluations([evaluation])
 
     for _ in range(n_max_evaluations):
 
@@ -89,9 +88,8 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         else:
             evaluation_result = {"loss": loss}
 
-        optimizer.report_evaluation(
-            eval_spec.create_evaluation(objectives=evaluation_result)
-        )
+        evaluation = eval_spec.create_evaluation(objectives=evaluation_result)
+        optimizer.report_evaluations([evaluation])
 
     return True
 
@@ -124,7 +122,8 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
         )
 
         es1 = opt.get_evaluation_specification()
-        opt.report_evaluation(es1.create_evaluation(objectives={"loss": 0.42}))
+        evaluation1 = es1.create_evaluation(objectives={"loss": 0.42})
+        opt.report_evaluations([evaluation1])
         es2 = opt.get_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
@@ -145,7 +144,8 @@ def raises_objectives_error_when_reporting_unknown_objective(
     es = opt.get_evaluation_specification()
 
     try:
-        opt.report_evaluation(es.create_evaluation(objectives={"unknown_objective": 0}))
+        evaluation = es.create_evaluation(objectives={"unknown_objective": 0})
+        opt.report_evaluations([evaluation])
 
         raise AssertionError(
             f"Optimizer {optimizer_class} did not raise an ObjectivesError when a "

--- a/blackboxopt/utils.py
+++ b/blackboxopt/utils.py
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from blackboxopt.base import Objective
+from blackboxopt.evaluation import Evaluation
 
 
 def get_loss_vector(
@@ -31,3 +32,11 @@ def get_loss_vector(
             losses.append(objective_value)
 
     return losses
+
+
+def filter_valid(
+    evaluations: Iterable[Evaluation],
+    evaluations_with_errors: List[Tuple[Evaluation, Exception]],
+):
+    invalid_evaluations = [evaluation for evaluation, _ in evaluations_with_errors]
+    return [e for e in evaluations if e not in invalid_evaluations]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,14 +1,6 @@
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "astroid"
-version = "2.6.2"
+version = "2.7.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -55,25 +47,31 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "black"
-version = "20.8b1"
+version = "21.8b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
-appdirs = "*"
 click = ">=7.1.2"
 mypy-extensions = ">=0.4.3"
-pathspec = ">=0.6,<1"
+pathspec = ">=0.9.0,<1"
+platformdirs = ">=2"
 regex = ">=2020.1.8"
-toml = ">=0.10.1"
-typed-ast = ">=1.4.0"
-typing-extensions = ">=3.7.4"
+tomli = ">=0.2.6,<2.0.0"
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+python2 = ["typed-ast (>=1.4.2)"]
+uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bracex"
@@ -132,7 +130,7 @@ toml = ["toml"]
 
 [[package]]
 name = "dask"
-version = "2021.7.0"
+version = "2021.8.1"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = true
@@ -141,21 +139,22 @@ python-versions = ">=3.7"
 [package.dependencies]
 cloudpickle = ">=1.1.1"
 fsspec = ">=0.6.0"
+packaging = ">=20.0"
 partd = ">=0.3.10"
 pyyaml = "*"
 toolz = ">=0.8.2"
 
 [package.extras]
-array = ["numpy (>=1.16)"]
-complete = ["bokeh (>=1.0.0,!=2.0.0)", "distributed (==2021.07.0)", "numpy (>=1.16)", "pandas (>=0.25.0)"]
-dataframe = ["numpy (>=1.16)", "pandas (>=0.25.0)"]
-diagnostics = ["bokeh (>=1.0.0,!=2.0.0)"]
-distributed = ["distributed (==2021.07.0)"]
+array = ["numpy (>=1.18)"]
+complete = ["bokeh (>=1.0.0,!=2.0.0)", "distributed (==2021.08.1)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
+diagnostics = ["bokeh (>=1.0.0,!=2.0.0)", "jinja2"]
+distributed = ["distributed (==2021.08.1)"]
 test = ["pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 [[package]]
 name = "distributed"
-version = "2021.7.0"
+version = "2021.8.1"
 description = "Distributed scheduler for Dask"
 category = "main"
 optional = true
@@ -164,7 +163,8 @@ python-versions = ">=3.7"
 [package.dependencies]
 click = ">=6.6"
 cloudpickle = ">=1.5.0"
-dask = "2021.07.0"
+dask = "2021.08.1"
+jinja2 = "*"
 msgpack = ">=0.6.0"
 psutil = ">=5.0"
 pyyaml = "*"
@@ -179,7 +179,7 @@ zict = ">=0.1.3"
 
 [[package]]
 name = "fsspec"
-version = "2021.7.0"
+version = "2021.8.1"
 description = "File-system specification"
 category = "main"
 optional = true
@@ -226,7 +226,7 @@ python-versions = "*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.6.1"
+version = "4.8.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -251,7 +251,7 @@ python-versions = "*"
 
 [[package]]
 name = "isort"
-version = "5.9.2"
+version = "5.9.3"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
@@ -267,7 +267,7 @@ plugins = ["setuptools"]
 name = "jinja2"
 version = "3.0.1"
 description = "A very fast and expressive template engine."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -311,7 +311,7 @@ testing = ["coverage", "pyyaml"]
 name = "markupsafe"
 version = "2.0.1"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -333,7 +333,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mike"
-version = "1.0.1"
+version = "1.1.0"
 description = "Manage multiple versions of your MkDocs-powered documentation"
 category = "dev"
 optional = false
@@ -342,12 +342,12 @@ python-versions = "*"
 [package.dependencies]
 jinja2 = "*"
 mkdocs = ">=1.0"
-pyyaml = "*"
+pyyaml = ">=5.1"
 verspec = "*"
 
 [package.extras]
-dev = ["coverage", "flake8 (>=3.0)"]
-test = ["coverage", "flake8 (>=3.0)"]
+dev = ["coverage", "flake8 (>=3.0)", "shtab"]
+test = ["coverage", "flake8 (>=3.0)", "shtab"]
 
 [[package]]
 name = "mkdocs"
@@ -409,7 +409,7 @@ mkdocs = ">=1.0.3,<2.0.0"
 
 [[package]]
 name = "mkdocs-material"
-version = "7.1.11"
+version = "7.2.6"
 description = "A Material Design theme for MkDocs"
 category = "dev"
 optional = false
@@ -417,7 +417,7 @@ python-versions = "*"
 
 [package.dependencies]
 markdown = ">=3.2"
-mkdocs = ">=1.1"
+mkdocs = ">=1.2.2"
 mkdocs-material-extensions = ">=1.0"
 Pygments = ">=2.4"
 pymdown-extensions = ">=7.0"
@@ -496,7 +496,7 @@ python-versions = ">=3.7"
 name = "packaging"
 version = "21.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -505,7 +505,7 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "pandas"
-version = "1.3.0"
+version = "1.3.2"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = true
@@ -567,6 +567,18 @@ numpy = ">=1.4"
 six = "*"
 
 [[package]]
+name = "platformdirs"
+version = "2.3.0"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
 name = "plotly"
 version = "4.14.3"
 description = "An open-source, interactive data visualization library for Python"
@@ -580,17 +592,18 @@ six = "*"
 
 [[package]]
 name = "pluggy"
-version = "0.13.1"
+version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psutil"
@@ -627,7 +640,7 @@ toml = ["toml"]
 
 [[package]]
 name = "pygments"
-version = "2.9.0"
+version = "2.10.0"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "dev"
 optional = false
@@ -635,17 +648,18 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pylint"
-version = "2.9.3"
+version = "2.10.2"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-astroid = ">=2.6.2,<2.7"
+astroid = ">=2.7.2,<2.8"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
+platformdirs = ">=2.2.0"
 toml = ">=0.7.1"
 
 [[package]]
@@ -663,13 +677,13 @@ Markdown = ">=3.2"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "6.2.4"
+version = "6.2.5"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
@@ -682,7 +696,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0.0a1"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
@@ -772,7 +786,7 @@ pyyaml = "*"
 
 [[package]]
 name = "regex"
-version = "2021.7.6"
+version = "2021.8.28"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -860,6 +874,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomli"
+version = "1.2.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "toolz"
 version = "0.11.1"
 description = "List processing tools and functional utilities"
@@ -885,7 +907,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.0"
+version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
@@ -904,7 +926,7 @@ test = ["coverage", "flake8 (>=3.7)", "mypy", "pretend", "pytest"]
 
 [[package]]
 name = "watchdog"
-version = "2.1.3"
+version = "2.1.5"
 description = "Filesystem events monitoring"
 category = "dev"
 optional = false
@@ -966,16 +988,12 @@ visualization = ["plotly", "scipy", "pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "3c61e65470c4f1a64bc16850f5ff1eb190c6e6eb8781abdbe1ce57213838c5e6"
+content-hash = "68ad14167f8d2d1555c02c37653e33854a7912e9f632e994f053519d0836f89a"
 
 [metadata.files]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
 astroid = [
-    {file = "astroid-2.6.2-py3-none-any.whl", hash = "sha256:606b2911d10c3dcf35e58d2ee5c97360e8477d7b9f3efc3f24811c93e6fc2cd9"},
-    {file = "astroid-2.6.2.tar.gz", hash = "sha256:38b95085e9d92e2ca06cf8b35c12a74fa81da395a6f9e65803742e6509c05892"},
+    {file = "astroid-2.7.3-py3-none-any.whl", hash = "sha256:dc1e8b28427d6bbef6b8842b18765ab58f558c42bb80540bd7648c98412af25e"},
+    {file = "astroid-2.7.3.tar.gz", hash = "sha256:3b680ce0419b8a771aba6190139a3998d14b413852506d99aff8dc2bf65ee67c"},
 ]
 astunparse = [
     {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
@@ -990,7 +1008,8 @@ attrs = [
     {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 black = [
-    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+    {file = "black-21.8b0-py3-none-any.whl", hash = "sha256:2a0f9a8c2b2a60dbcf1ccb058842fb22bdbbcb2f32c6cc02d9578f90b92ce8b7"},
+    {file = "black-21.8b0.tar.gz", hash = "sha256:570608d28aa3af1792b98c4a337dbac6367877b47b12b88ab42095cfc1a627c2"},
 ]
 bracex = [
     {file = "bracex-2.1.1-py3-none-any.whl", hash = "sha256:64e2a6d14de9c8e022cf40539ac8468ba7c4b99550a2b05fc87fd20e392e568f"},
@@ -1067,16 +1086,16 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 dask = [
-    {file = "dask-2021.7.0-py3-none-any.whl", hash = "sha256:7ef39f608a6186a4d910462449b2b75c6da7e8a10eca31686b06638837346e18"},
-    {file = "dask-2021.7.0.tar.gz", hash = "sha256:a672df4831ed4a37dd9e0ae1903115ab208808b551aca3ed412eede5f7b7b1f5"},
+    {file = "dask-2021.8.1-py3-none-any.whl", hash = "sha256:61504a7d369081fdf417e8a1dcb461181416f8d0638073105788592bd1bf3eb7"},
+    {file = "dask-2021.8.1.tar.gz", hash = "sha256:89efe49dfef162387a89c8b255b30ef495856405786ef94884df985fe1a344bd"},
 ]
 distributed = [
-    {file = "distributed-2021.7.0-py3-none-any.whl", hash = "sha256:5baea0941c4f7966a99c6f200f83cde490aecc0c282e96a0e46977747a5bf0e4"},
-    {file = "distributed-2021.7.0.tar.gz", hash = "sha256:6257f399ea564bfdcd80dcc9df6cdaf703dbadb94b7c068d103f8366dc7f8d1f"},
+    {file = "distributed-2021.8.1-py3-none-any.whl", hash = "sha256:2ac3df144772ab2f959a71af3962c5adb5d0bd826a2a618bf3ce44df15107482"},
+    {file = "distributed-2021.8.1.tar.gz", hash = "sha256:c13ac10ecd9ee5f0ff67f5697149062d6e483f23a079918df1ab2e19b11fa77d"},
 ]
 fsspec = [
-    {file = "fsspec-2021.7.0-py3-none-any.whl", hash = "sha256:86822ccf367da99957f49db64f7d5fd3d8d21444fac4dfdc8ebc38ee93d478c6"},
-    {file = "fsspec-2021.7.0.tar.gz", hash = "sha256:792ebd3b54de0b30f1ce73f0ba0a8bcc864724f2d9f248cb8d0ece47db0cbde8"},
+    {file = "fsspec-2021.8.1-py3-none-any.whl", hash = "sha256:30f27c059a414d1f434b14b2d0e75c8d9c3dd473ad8daeccb444d9d4069b9f03"},
+    {file = "fsspec-2021.8.1.tar.gz", hash = "sha256:af125917788b77782899bbd4484d29e5407f53d2bb04cdfa025fe4931201a555"},
 ]
 ghp-import = [
     {file = "ghp-import-2.0.1.tar.gz", hash = "sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483"},
@@ -1086,16 +1105,16 @@ heapdict = [
     {file = "HeapDict-1.0.1.tar.gz", hash = "sha256:8495f57b3e03d8e46d5f1b2cc62ca881aca392fd5cc048dc0aa2e1a6d23ecdb6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.6.1-py3-none-any.whl", hash = "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"},
-    {file = "importlib_metadata-4.6.1.tar.gz", hash = "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac"},
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
-    {file = "isort-5.9.2-py3-none-any.whl", hash = "sha256:eed17b53c3e7912425579853d078a0832820f023191561fcee9d7cae424e0813"},
-    {file = "isort-5.9.2.tar.gz", hash = "sha256:f65ce5bd4cbc6abdfbe29afc2f0245538ab358c14590912df638033f157d555e"},
+    {file = "isort-5.9.3-py3-none-any.whl", hash = "sha256:e17d6e2b81095c9db0a03a8025a957f334d6ea30b26f9ec70805411e5c7c81f2"},
+    {file = "isort-5.9.3.tar.gz", hash = "sha256:9c2ea1e62d871267b78307fe511c0838ba0da28698c5732d54e2790bf3ba9899"},
 ]
 jinja2 = [
     {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
@@ -1178,8 +1197,8 @@ mergedeep = [
     {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
 ]
 mike = [
-    {file = "mike-1.0.1-py3-none-any.whl", hash = "sha256:29b39a725510a67590db261ca8292f583dcfe06c6ea6842793c96ae631d6e2e1"},
-    {file = "mike-1.0.1.tar.gz", hash = "sha256:7888f01d05d752bd43e03f6d971608a0b876f23787cf49a1f2b43be304b1789e"},
+    {file = "mike-1.1.0-py3-none-any.whl", hash = "sha256:cabb89fd8d01f3546ae2d155b23bdaa4c454b7821afdd017704396de1425d563"},
+    {file = "mike-1.1.0.tar.gz", hash = "sha256:018eba2770bba5ce91f4575fcdf3f4e9d2c69937e1b023a8c47e7a3c28c6d647"},
 ]
 mkdocs = [
     {file = "mkdocs-1.2.2-py3-none-any.whl", hash = "sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff"},
@@ -1198,8 +1217,8 @@ mkdocs-gen-files = [
     {file = "mkdocs_gen_files-0.3.3-py3-none-any.whl", hash = "sha256:bcfbaa496c5fc8164a9a243963e444c8750c619e18cd54e217549586c9132461"},
 ]
 mkdocs-material = [
-    {file = "mkdocs-material-7.1.11.tar.gz", hash = "sha256:cad3a693f1c28823370578e5b9c9aea418bddae0c7348ab734537391e9f2b1e5"},
-    {file = "mkdocs_material-7.1.11-py2.py3-none-any.whl", hash = "sha256:0bcfb788020b72b0ebf5b2722ddf89534acaed8c3feb39c2d6dda239b49dec45"},
+    {file = "mkdocs-material-7.2.6.tar.gz", hash = "sha256:4bdeff63904680865676ceb3193216934de0b33fa5b2446e0a84ade60929ee54"},
+    {file = "mkdocs_material-7.2.6-py2.py3-none-any.whl", hash = "sha256:4c6939b9d7d5c6db948ab02df8525c64211828ddf33286acea8b9d2115cec369"},
 ]
 mkdocs-material-extensions = [
     {file = "mkdocs-material-extensions-1.0.1.tar.gz", hash = "sha256:6947fb7f5e4291e3c61405bad3539d81e0b3cd62ae0d66ced018128af509c68f"},
@@ -1303,25 +1322,25 @@ packaging = [
     {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pandas = [
-    {file = "pandas-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c81b8d91e9ae861eb4406b4e0f8d4dabbc105b9c479b3d1e921fba1d35b5b62a"},
-    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08eeff3da6a188e24db7f292b39a8ca9e073bf841fbbeadb946b3ad5c19d843e"},
-    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:88864c1e28353b958b1f30e4193818519624ad9a1776921622a6a2a016d5d807"},
-    {file = "pandas-1.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:872aa91e0f9ca913046ab639d4181a899f5e592030d954d28c2529b88756a736"},
-    {file = "pandas-1.3.0-cp37-cp37m-win32.whl", hash = "sha256:92835113a67cbd34747c198d41f09f4b63f6fe11ca5643baebc7ab1e30e89e95"},
-    {file = "pandas-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:7d3cd2c99faa94d717ca00ea489264a291ad7209453dffbf059bfb7971fd3a61"},
-    {file = "pandas-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:823737830364d0e2af8c3912a28ba971296181a07950873492ed94e12d28c405"},
-    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c746876cdd8380be0c3e70966d4566855901ac9aaa5e4b9ccaa5ca5311457d11"},
-    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe7a549d10ca534797095586883a5c17d140d606747591258869c56e14d1b457"},
-    {file = "pandas-1.3.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f058c786e7b0a9e7fa5e0b9f4422e0ccdd3bf3aa3053c18d77ed2a459bd9a45a"},
-    {file = "pandas-1.3.0-cp38-cp38-win32.whl", hash = "sha256:98efc2d4983d5bb47662fe2d97b2c81b91566cb08b266490918b9c7d74a5ef64"},
-    {file = "pandas-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:e6b75091fa54a53db3927b4d1bc997c23c5ba6f87acdfe1ee5a92c38c6b2ed6a"},
-    {file = "pandas-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1ff13eed501e07e7fb26a4ea18a846b6e5d7de549b497025601fd9ccb7c1d123"},
-    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798675317d0e4863a92a9a6bc5bd2490b5f6fef8c17b95f29e2e33f28bef9eca"},
-    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ed4fc66f23fe17c93a5d439230ca2d6b5f8eac7154198d327dbe8a16d98f3f10"},
-    {file = "pandas-1.3.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:522bfea92f3ef6207cadc7428bda1e7605dae0383b8065030e7b5d0266717b48"},
-    {file = "pandas-1.3.0-cp39-cp39-win32.whl", hash = "sha256:7897326cae660eee69d501cbfa950281a193fcf407393965e1bc07448e1cc35a"},
-    {file = "pandas-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:b10d7910ae9d7920a5ff7816d794d99acbc361f7b16a0f017d4fa83ced8cb55e"},
-    {file = "pandas-1.3.0.tar.gz", hash = "sha256:c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2"},
+    {file = "pandas-1.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ba7ceb8abc6dbdb1e34612d1173d61e4941f1a1eb7e6f703b2633134ae6a6c89"},
+    {file = "pandas-1.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fcb71b1935249de80e3a808227189eee381d4d74a31760ced2df21eedc92a8e3"},
+    {file = "pandas-1.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa54dc1d3e5d004a09ab0b1751473698011ddf03e14f1f59b84ad9a6ac630975"},
+    {file = "pandas-1.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34ced9ce5d5b17b556486da7256961b55b471d64a8990b56e67a84ebeb259416"},
+    {file = "pandas-1.3.2-cp37-cp37m-win32.whl", hash = "sha256:a56246de744baf646d1f3e050c4653d632bc9cd2e0605f41051fea59980e880a"},
+    {file = "pandas-1.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:53b17e4debba26b7446b1e4795c19f94f0c715e288e08145e44bdd2865e819b3"},
+    {file = "pandas-1.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f07a9745ca075ae73a5ce116f5e58f691c0dc9de0bff163527858459df5c176f"},
+    {file = "pandas-1.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9e8e0ce5284ebebe110efd652c164ed6eab77f5de4c3533abc756302ee77765"},
+    {file = "pandas-1.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a78d7066d1c921a77e3306aa0ebf6e55396c097d5dfcc4df8defe3dcecb735"},
+    {file = "pandas-1.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:132def05e73d292c949b02e7ef873debb77acc44a8b119d215921046f0c3a91d"},
+    {file = "pandas-1.3.2-cp38-cp38-win32.whl", hash = "sha256:69e1b2f5811f46827722fd641fdaeedb26002bd1e504eacc7a8ec36bdc25393e"},
+    {file = "pandas-1.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:7996d311413379136baf0f3cf2a10e331697657c87ced3f17ac7c77f77fe34a3"},
+    {file = "pandas-1.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1738154049062156429a5cf2fd79a69c9f3fa4f231346a7ec6fd156cd1a9a621"},
+    {file = "pandas-1.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cce01f6d655b4add966fcd36c32c5d1fe84628e200626b3f5e2f40db2d16a0f"},
+    {file = "pandas-1.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1099e2a0cd3a01ec62cca183fc1555833a2d43764950ef8cb5948c8abfc51014"},
+    {file = "pandas-1.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cd5776be891331a3e6b425b5abeab9596abea18435c5982191356f9b24ae731"},
+    {file = "pandas-1.3.2-cp39-cp39-win32.whl", hash = "sha256:66a95361b81b4ba04b699ecd2416b0591f40cd1e24c60a8bfe0d19009cfa575a"},
+    {file = "pandas-1.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:89f40e5d21814192802421df809f948247d39ffe171e45fe2ab4abf7bd4279d8"},
+    {file = "pandas-1.3.2.tar.gz", hash = "sha256:cbcb84d63867af3411fa063af3de64902665bb5b3d40b25b2059e40603594e87"},
 ]
 parameterspace = [
     {file = "parameterspace-0.7.11-py3-none-any.whl", hash = "sha256:b5c3ad19d376d6d2f41eab77843ec8956ca260a9a109f709b3c06db75f3be727"},
@@ -1339,13 +1358,17 @@ patsy = [
     {file = "patsy-0.5.1-py2.py3-none-any.whl", hash = "sha256:5465be1c0e670c3a965355ec09e9a502bf2c4cbe4875e8528b0221190a8a5d40"},
     {file = "patsy-0.5.1.tar.gz", hash = "sha256:f115cec4201e1465cd58b9866b0b0e7b941caafec129869057405bfe5b5e3991"},
 ]
+platformdirs = [
+    {file = "platformdirs-2.3.0-py3-none-any.whl", hash = "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"},
+    {file = "platformdirs-2.3.0.tar.gz", hash = "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f"},
+]
 plotly = [
     {file = "plotly-4.14.3-py2.py3-none-any.whl", hash = "sha256:d68fc15fcb49f88db27ab3e0c87110943e65fee02a47f33a8590f541b3042461"},
     {file = "plotly-4.14.3.tar.gz", hash = "sha256:7d8aaeed392e82fb8e0e48899f2d3d957b12327f9d38cdd5802bc574a8a39d91"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 psutil = [
     {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
@@ -1386,12 +1409,12 @@ pydocstyle = [
     {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
 ]
 pygments = [
-    {file = "Pygments-2.9.0-py3-none-any.whl", hash = "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"},
-    {file = "Pygments-2.9.0.tar.gz", hash = "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f"},
+    {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},
+    {file = "Pygments-2.10.0.tar.gz", hash = "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"},
 ]
 pylint = [
-    {file = "pylint-2.9.3-py3-none-any.whl", hash = "sha256:5d46330e6b8886c31b5e3aba5ff48c10f4aa5e76cbf9002c6544306221e63fbc"},
-    {file = "pylint-2.9.3.tar.gz", hash = "sha256:23a1dc8b30459d78e9ff25942c61bb936108ccbe29dd9e71c01dc8274961709a"},
+    {file = "pylint-2.10.2-py3-none-any.whl", hash = "sha256:e178e96b6ba171f8ef51fbce9ca30931e6acbea4a155074d80cc081596c9e852"},
+    {file = "pylint-2.10.2.tar.gz", hash = "sha256:6758cce3ddbab60c52b57dcc07f0c5d779e5daf0cf50f6faacbef1d3ea62d2a1"},
 ]
 pymdown-extensions = [
     {file = "pymdown-extensions-8.2.tar.gz", hash = "sha256:b6daa94aad9e1310f9c64c8b1f01e4ce82937ab7eb53bfc92876a97aca02a6f4"},
@@ -1402,8 +1425,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
-    {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
@@ -1461,47 +1484,47 @@ pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
 ]
 regex = [
-    {file = "regex-2021.7.6-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e6a1e5ca97d411a461041d057348e578dc344ecd2add3555aedba3b408c9f874"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6afe6a627888c9a6cfbb603d1d017ce204cebd589d66e0703309b8048c3b0854"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ccb3d2190476d00414aab36cca453e4596e8f70a206e2aa8db3d495a109153d2"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:ed693137a9187052fc46eedfafdcb74e09917166362af4cc4fddc3b31560e93d"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99d8ab206a5270c1002bfcf25c51bf329ca951e5a169f3b43214fdda1f0b5f0d"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:b85ac458354165405c8a84725de7bbd07b00d9f72c31a60ffbf96bb38d3e25fa"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3f5716923d3d0bfb27048242a6e0f14eecdb2e2a7fac47eda1d055288595f222"},
-    {file = "regex-2021.7.6-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5983c19d0beb6af88cb4d47afb92d96751fb3fa1784d8785b1cdf14c6519407"},
-    {file = "regex-2021.7.6-cp36-cp36m-win32.whl", hash = "sha256:c92831dac113a6e0ab28bc98f33781383fe294df1a2c3dfd1e850114da35fd5b"},
-    {file = "regex-2021.7.6-cp36-cp36m-win_amd64.whl", hash = "sha256:791aa1b300e5b6e5d597c37c346fb4d66422178566bbb426dd87eaae475053fb"},
-    {file = "regex-2021.7.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59506c6e8bd9306cd8a41511e32d16d5d1194110b8cfe5a11d102d8b63cf945d"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:564a4c8a29435d1f2256ba247a0315325ea63335508ad8ed938a4f14c4116a5d"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:59c00bb8dd8775473cbfb967925ad2c3ecc8886b3b2d0c90a8e2707e06c743f0"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:9a854b916806c7e3b40e6616ac9e85d3cdb7649d9e6590653deb5b341a736cec"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:db2b7df831c3187a37f3bb80ec095f249fa276dbe09abd3d35297fc250385694"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:173bc44ff95bc1e96398c38f3629d86fa72e539c79900283afa895694229fe6a"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:15dddb19823f5147e7517bb12635b3c82e6f2a3a6b696cc3e321522e8b9308ad"},
-    {file = "regex-2021.7.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2ddeabc7652024803666ea09f32dd1ed40a0579b6fbb2a213eba590683025895"},
-    {file = "regex-2021.7.6-cp37-cp37m-win32.whl", hash = "sha256:f080248b3e029d052bf74a897b9d74cfb7643537fbde97fe8225a6467fb559b5"},
-    {file = "regex-2021.7.6-cp37-cp37m-win_amd64.whl", hash = "sha256:d8bbce0c96462dbceaa7ac4a7dfbbee92745b801b24bce10a98d2f2b1ea9432f"},
-    {file = "regex-2021.7.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edd1a68f79b89b0c57339bce297ad5d5ffcc6ae7e1afdb10f1947706ed066c9c"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux1_i686.whl", hash = "sha256:422dec1e7cbb2efbbe50e3f1de36b82906def93ed48da12d1714cabcd993d7f0"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cbe23b323988a04c3e5b0c387fe3f8f363bf06c0680daf775875d979e376bd26"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0eb2c6e0fcec5e0f1d3bcc1133556563222a2ffd2211945d7b1480c1b1a42a6f"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1c78780bf46d620ff4fff40728f98b8afd8b8e35c3efd638c7df67be2d5cddbf"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bc84fb254a875a9f66616ed4538542fb7965db6356f3df571d783f7c8d256edd"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:598c0a79b4b851b922f504f9f39a863d83ebdfff787261a5ed061c21e67dd761"},
-    {file = "regex-2021.7.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:875c355360d0f8d3d827e462b29ea7682bf52327d500a4f837e934e9e4656068"},
-    {file = "regex-2021.7.6-cp38-cp38-win32.whl", hash = "sha256:e586f448df2bbc37dfadccdb7ccd125c62b4348cb90c10840d695592aa1b29e0"},
-    {file = "regex-2021.7.6-cp38-cp38-win_amd64.whl", hash = "sha256:2fe5e71e11a54e3355fa272137d521a40aace5d937d08b494bed4529964c19c4"},
-    {file = "regex-2021.7.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6110bab7eab6566492618540c70edd4d2a18f40ca1d51d704f1d81c52d245026"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4f64fc59fd5b10557f6cd0937e1597af022ad9b27d454e182485f1db3008f417"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:89e5528803566af4df368df2d6f503c84fbfb8249e6631c7b025fe23e6bd0cde"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2366fe0479ca0e9afa534174faa2beae87847d208d457d200183f28c74eaea59"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f9392a4555f3e4cb45310a65b403d86b589adc773898c25a39184b1ba4db8985"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2bceeb491b38225b1fee4517107b8491ba54fba77cf22a12e996d96a3c55613d"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f98dc35ab9a749276f1a4a38ab3e0e2ba1662ce710f6530f5b0a6656f1c32b58"},
-    {file = "regex-2021.7.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:319eb2a8d0888fa6f1d9177705f341bc9455a2c8aca130016e52c7fe8d6c37a3"},
-    {file = "regex-2021.7.6-cp39-cp39-win32.whl", hash = "sha256:eaf58b9e30e0e546cdc3ac06cf9165a1ca5b3de8221e9df679416ca667972035"},
-    {file = "regex-2021.7.6-cp39-cp39-win_amd64.whl", hash = "sha256:4c9c3155fe74269f61e27617529b7f09552fbb12e44b1189cebbdb24294e6e1c"},
-    {file = "regex-2021.7.6.tar.gz", hash = "sha256:8394e266005f2d8c6f0bc6780001f7afa3ef81a7a2111fa35058ded6fce79e4d"},
+    {file = "regex-2021.8.28-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9d05ad5367c90814099000442b2125535e9d77581855b9bee8780f1b41f2b1a2"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3bf1bc02bc421047bfec3343729c4bbbea42605bcfd6d6bfe2c07ade8b12d2a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6a808044faae658f546dd5f525e921de9fa409de7a5570865467f03a626fc0"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a617593aeacc7a691cc4af4a4410031654f2909053bd8c8e7db837f179a630eb"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79aef6b5cd41feff359acaf98e040844613ff5298d0d19c455b3d9ae0bc8c35a"},
+    {file = "regex-2021.8.28-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0fc1f8f06977c2d4f5e3d3f0d4a08089be783973fc6b6e278bde01f0544ff308"},
+    {file = "regex-2021.8.28-cp310-cp310-win32.whl", hash = "sha256:6eebf512aa90751d5ef6a7c2ac9d60113f32e86e5687326a50d7686e309f66ed"},
+    {file = "regex-2021.8.28-cp310-cp310-win_amd64.whl", hash = "sha256:ac88856a8cbccfc14f1b2d0b829af354cc1743cb375e7f04251ae73b2af6adf8"},
+    {file = "regex-2021.8.28-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c206587c83e795d417ed3adc8453a791f6d36b67c81416676cad053b4104152c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8690ed94481f219a7a967c118abaf71ccc440f69acd583cab721b90eeedb77c"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:328a1fad67445550b982caa2a2a850da5989fd6595e858f02d04636e7f8b0b13"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c7cb4c512d2d3b0870e00fbbac2f291d4b4bf2634d59a31176a87afe2777c6f0"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66256b6391c057305e5ae9209941ef63c33a476b73772ca967d4a2df70520ec1"},
+    {file = "regex-2021.8.28-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8e44769068d33e0ea6ccdf4b84d80c5afffe5207aa4d1881a629cf0ef3ec398f"},
+    {file = "regex-2021.8.28-cp36-cp36m-win32.whl", hash = "sha256:08d74bfaa4c7731b8dac0a992c63673a2782758f7cfad34cf9c1b9184f911354"},
+    {file = "regex-2021.8.28-cp36-cp36m-win_amd64.whl", hash = "sha256:abb48494d88e8a82601af905143e0de838c776c1241d92021e9256d5515b3645"},
+    {file = "regex-2021.8.28-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4c220a1fe0d2c622493b0a1fd48f8f991998fb447d3cd368033a4b86cf1127a"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4a332404baa6665b54e5d283b4262f41f2103c255897084ec8f5487ce7b9e8e"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c61dcc1cf9fd165127a2853e2c31eb4fb961a4f26b394ac9fe5669c7a6592892"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ee329d0387b5b41a5dddbb6243a21cb7896587a651bebb957e2d2bb8b63c0791"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f60667673ff9c249709160529ab39667d1ae9fd38634e006bec95611f632e759"},
+    {file = "regex-2021.8.28-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b844fb09bd9936ed158ff9df0ab601e2045b316b17aa8b931857365ea8586906"},
+    {file = "regex-2021.8.28-cp37-cp37m-win32.whl", hash = "sha256:4cde065ab33bcaab774d84096fae266d9301d1a2f5519d7bd58fc55274afbf7a"},
+    {file = "regex-2021.8.28-cp37-cp37m-win_amd64.whl", hash = "sha256:1413b5022ed6ac0d504ba425ef02549a57d0f4276de58e3ab7e82437892704fc"},
+    {file = "regex-2021.8.28-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ed4b50355b066796dacdd1cf538f2ce57275d001838f9b132fab80b75e8c84dd"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28fc475f560d8f67cc8767b94db4c9440210f6958495aeae70fac8faec631797"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdc178caebd0f338d57ae445ef8e9b737ddf8fbc3ea187603f65aec5b041248f"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:999ad08220467b6ad4bd3dd34e65329dd5d0df9b31e47106105e407954965256"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:808ee5834e06f57978da3e003ad9d6292de69d2bf6263662a1a8ae30788e080b"},
+    {file = "regex-2021.8.28-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d5111d4c843d80202e62b4fdbb4920db1dcee4f9366d6b03294f45ed7b18b42e"},
+    {file = "regex-2021.8.28-cp38-cp38-win32.whl", hash = "sha256:473858730ef6d6ff7f7d5f19452184cd0caa062a20047f6d6f3e135a4648865d"},
+    {file = "regex-2021.8.28-cp38-cp38-win_amd64.whl", hash = "sha256:31a99a4796bf5aefc8351e98507b09e1b09115574f7c9dbb9cf2111f7220d2e2"},
+    {file = "regex-2021.8.28-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:04f6b9749e335bb0d2f68c707f23bb1773c3fb6ecd10edf0f04df12a8920d468"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9b006628fe43aa69259ec04ca258d88ed19b64791693df59c422b607b6ece8bb"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:121f4b3185feaade3f85f70294aef3f777199e9b5c0c0245c774ae884b110a2d"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a577a21de2ef8059b58f79ff76a4da81c45a75fe0bfb09bc8b7bb4293fa18983"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1743345e30917e8c574f273f51679c294effba6ad372db1967852f12c76759d8"},
+    {file = "regex-2021.8.28-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e1e8406b895aba6caa63d9fd1b6b1700d7e4825f78ccb1e5260551d168db38ed"},
+    {file = "regex-2021.8.28-cp39-cp39-win32.whl", hash = "sha256:ed283ab3a01d8b53de3a05bfdf4473ae24e43caee7dcb5584e86f3f3e5ab4374"},
+    {file = "regex-2021.8.28-cp39-cp39-win_amd64.whl", hash = "sha256:610b690b406653c84b7cb6091facb3033500ee81089867ee7d59e675f9ca2b73"},
+    {file = "regex-2021.8.28.tar.gz", hash = "sha256:f585cbbeecb35f35609edccb95efd95a3e35824cd7752b586503f7e6087303f1"},
 ]
 retrying = [
     {file = "retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"},
@@ -1569,6 +1592,10 @@ tblib = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
+    {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
 ]
 toolz = [
     {file = "toolz-0.11.1-py3-none-any.whl", hash = "sha256:1bc473acbf1a1db4e72a1ce587be347450e8f08324908b8a266b486f408f04d5"},
@@ -1650,36 +1677,38 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},
-    {file = "typing_extensions-3.10.0.0-py3-none-any.whl", hash = "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"},
-    {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 verspec = [
     {file = "verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31"},
     {file = "verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e"},
 ]
 watchdog = [
-    {file = "watchdog-2.1.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9628f3f85375a17614a2ab5eac7665f7f7be8b6b0a2a228e6f6a2e91dd4bfe26"},
-    {file = "watchdog-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:acc4e2d5be6f140f02ee8590e51c002829e2c33ee199036fcd61311d558d89f4"},
-    {file = "watchdog-2.1.3-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:85b851237cf3533fabbc034ffcd84d0fa52014b3121454e5f8b86974b531560c"},
-    {file = "watchdog-2.1.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a12539ecf2478a94e4ba4d13476bb2c7a2e0a2080af2bb37df84d88b1b01358a"},
-    {file = "watchdog-2.1.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6fe9c8533e955c6589cfea6f3f0a1a95fb16867a211125236c82e1815932b5d7"},
-    {file = "watchdog-2.1.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d9456f0433845e7153b102fffeb767bde2406b76042f2216838af3b21707894e"},
-    {file = "watchdog-2.1.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fd8c595d5a93abd441ee7c5bb3ff0d7170e79031520d113d6f401d0cf49d7c8f"},
-    {file = "watchdog-2.1.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0bcfe904c7d404eb6905f7106c54873503b442e8e918cc226e1828f498bdc0ca"},
-    {file = "watchdog-2.1.3-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:bf84bd94cbaad8f6b9cbaeef43080920f4cb0e61ad90af7106b3de402f5fe127"},
-    {file = "watchdog-2.1.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b8ddb2c9f92e0c686ea77341dcb58216fa5ff7d5f992c7278ee8a392a06e86bb"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8805a5f468862daf1e4f4447b0ccf3acaff626eaa57fbb46d7960d1cf09f2e6d"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_armv7l.whl", hash = "sha256:3e305ea2757f81d8ebd8559d1a944ed83e3ab1bdf68bcf16ec851b97c08dc035"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_i686.whl", hash = "sha256:431a3ea70b20962e6dee65f0eeecd768cd3085ea613ccb9b53c8969de9f6ebd2"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_ppc64.whl", hash = "sha256:e4929ac2aaa2e4f1a30a36751160be391911da463a8799460340901517298b13"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:201cadf0b8c11922f54ec97482f95b2aafca429c4c3a4bb869a14f3c20c32686"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_s390x.whl", hash = "sha256:3a7d242a7963174684206093846537220ee37ba9986b824a326a8bb4ef329a33"},
-    {file = "watchdog-2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:54e057727dd18bd01a3060dbf5104eb5a495ca26316487e0f32a394fd5fe725a"},
-    {file = "watchdog-2.1.3-py3-none-win32.whl", hash = "sha256:b5fc5c127bad6983eecf1ad117ab3418949f18af9c8758bd10158be3647298a9"},
-    {file = "watchdog-2.1.3-py3-none-win_amd64.whl", hash = "sha256:44acad6f642996a2b50bb9ce4fb3730dde08f23e79e20cd3d8e2a2076b730381"},
-    {file = "watchdog-2.1.3-py3-none-win_ia64.whl", hash = "sha256:0bcdf7b99b56a3ae069866c33d247c9994ffde91b620eaf0306b27e099bd1ae0"},
-    {file = "watchdog-2.1.3.tar.gz", hash = "sha256:e5236a8e8602ab6db4b873664c2d356c365ab3cac96fbdec4970ad616415dd45"},
+    {file = "watchdog-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5f57ce4f7e498278fb2a091f39359930144a0f2f90ea8cbf4523c4e25de34028"},
+    {file = "watchdog-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8b74d0d92a69a7ab5f101f9fe74e44ba017be269efa824337366ccbb4effde85"},
+    {file = "watchdog-2.1.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:59767f476cd1f48531bf378f0300565d879688c82da8369ca8c52f633299523c"},
+    {file = "watchdog-2.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:814d396859c95598f7576d15bc257c3bd3ba61fa4bc1db7dfc18f09070ded7da"},
+    {file = "watchdog-2.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:28777dbed3bbd95f9c70f461443990a36c07dbf49ae7cd69932cdd1b8fb2850c"},
+    {file = "watchdog-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5cf78f794c9d7bc64a626ef4f71aff88f57a7ae288e0b359a9c6ea711a41395f"},
+    {file = "watchdog-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:43bf728eb7830559f329864ab5da2302c15b2efbac24ad84ccc09949ba753c40"},
+    {file = "watchdog-2.1.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a7053d4d22dc95c5e0c90aeeae1e4ed5269d2f04001798eec43a654a03008d22"},
+    {file = "watchdog-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6f3ad1d973fe8fc8fe64ba38f6a934b74346342fa98ef08ad5da361a05d46044"},
+    {file = "watchdog-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:41d44ef21a77a32b55ce9bf59b75777063751f688de51098859b7c7f6466589a"},
+    {file = "watchdog-2.1.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ed4ca4351cd2bb0d863ee737a2011ca44d8d8be19b43509bd4507f8a449b376b"},
+    {file = "watchdog-2.1.5-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:8874d5ad6b7f43b18935d9b0183e29727a623a216693d6938d07dfd411ba462f"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_aarch64.whl", hash = "sha256:50a7f81f99d238f72185f481b493f9de80096e046935b60ea78e1276f3d76960"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_armv7l.whl", hash = "sha256:e40e33a4889382824846b4baa05634e1365b47c6fa40071dc2d06b4d7c715fc1"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_i686.whl", hash = "sha256:78b1514067ff4089f4dac930b043a142997a5b98553120919005e97fbaba6546"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_ppc64.whl", hash = "sha256:58ae842300cbfe5e62fb068c83901abe76e4f413234b7bec5446e4275eb1f9cb"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:b0cc7d8b7d60da6c313779d85903ce39a63d89d866014b085f720a083d5f3e9a"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_s390x.whl", hash = "sha256:e60d3bb7166b7cb830b86938d1eb0e6cfe23dfd634cce05c128f8f9967895193"},
+    {file = "watchdog-2.1.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:51af09ae937ada0e9a10cc16988ec03c649754a91526170b6839b89fc56d6acb"},
+    {file = "watchdog-2.1.5-py3-none-win32.whl", hash = "sha256:9391003635aa783957b9b11175d9802d3272ed67e69ef2e3394c0b6d9d24fa9a"},
+    {file = "watchdog-2.1.5-py3-none-win_amd64.whl", hash = "sha256:eab14adfc417c2c983fbcb2c73ef3f28ba6990d1fff45d1180bf7e38bda0d98d"},
+    {file = "watchdog-2.1.5-py3-none-win_ia64.whl", hash = "sha256:a2888a788893c4ef7e562861ec5433875b7915f930a5a7ed3d32c048158f1be5"},
+    {file = "watchdog-2.1.5.tar.gz", hash = "sha256:5563b005907613430ef3d4aaac9c78600dd5704e84764cb6deda4b3d72807f09"},
 ]
 wcmatch = [
     {file = "wcmatch-8.2-py3-none-any.whl", hash = "sha256:9146b1ab9354e0797ef6ef69bc89cb32cb9f46d1b9eeef69c559aeec8f3bffb6"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -988,7 +988,7 @@ visualization = ["plotly", "scipy", "pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "68ad14167f8d2d1555c02c37653e33854a7912e9f632e994f053519d0836f89a"
+content-hash = "a352ecc74860a7c039be068294252f62308f6f9d7dfa8bf48bc73a5ccfcff7b8"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "1.0.4"
+version = "1.0.5"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ distributed = {version = "^2021.2.0", optional = true}
 pandas = {version = "^1.2.4", optional = true}
 
 [tool.poetry.dev-dependencies]
-black = "^20.8b1"
+black = "^21.8b0"
 isort = "^5.7.0"
 pytest = "^6.2.2"
 mypy = "^0.910"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ mkdocs-material = "^7.1.11"
 pytest-cov = "^2.11.1"
 mkdocs-gen-files = "^0.3.1"
 mkdocs-awesome-pages-plugin = "^2.5.0"
-mike = "^1.0.1"
+mike = "^1.1.0"
 pylint = "^2.8.2"
 pydocstyle = "^6.1.1"
 
@@ -60,7 +60,7 @@ exclude = '^blackboxopt/examples/'
 
 [tool.isort]
 profile = "black"
-# Isort also tries has line length which is 80 for examples:
+# Examples should remain with line-length 80:
 skip_glob = 'blackboxopt/examples/**'
 
 [tool.pylint.format]

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -36,7 +36,7 @@ def test_bohb_sequential():
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
     es = opt.get_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
@@ -44,7 +44,7 @@ def test_bohb_sequential():
         opt.get_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": 0.0})
-    opt.report_evaluations(evaluation)
+    opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()
@@ -74,7 +74,7 @@ def test_bohb_parallel():
 
     for i, eval_spec in enumerate(eval_specs):
         evaluation = eval_spec.create_evaluation(objectives={"loss": i})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     assert len(opt.pending_configurations) == 0
 
@@ -86,7 +86,7 @@ def test_bohb_parallel():
         assert es.optimizer_info["configuration_key"] == (1, 0, i)
 
 
-def test_bohb_report_evaluations_as_batch():
+def test_bohb_report_as_batch():
     paramspace = ps.ParameterSpace()
     paramspace.add(ps.ContinuousParameter("p1", [0, 1]))
     opt = BOHB(
@@ -110,7 +110,7 @@ def test_bohb_report_evaluations_as_batch():
 
     assert len(opt.pending_configurations) == 3
     with pytest.warns(UserWarning, match=r"Skip.+missing.+specification ID.+$"):
-        opt.report_evaluations(evaluations)
+        opt.report(evaluations)
     assert len(opt.pending_configurations) == 0
 
 
@@ -175,14 +175,14 @@ def test_bohb_sequential_with_failed_evaluations(n_evaluations=16):
             )
         else:
             evaluation = es.create_evaluation(objectives={"loss": None})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()
@@ -222,14 +222,14 @@ def test_bohb_sequential_with_non_finite_losses(n_evaluations=16):
             evaluation = es.create_evaluation(
                 result={"loss": return_values[i // len(return_values)]}
             )
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+import re
 
 import numpy as np
 import parameterspace as ps
 import pytest
 
 from blackboxopt import OptimizationComplete, OptimizerNotReady
-from blackboxopt.base import Objective
+from blackboxopt.base import EvaluationsError, Objective
 from blackboxopt.evaluation import Evaluation
 from blackboxopt.optimizers.bohb import BOHB
 from blackboxopt.optimizers.testing import ALL_REFERENCE_TESTS
@@ -109,9 +110,11 @@ def test_bohb_report_as_batch():
     evaluations.append(invalid_evaluation)
 
     assert len(opt.pending_configurations) == 3
-    with pytest.warns(UserWarning, match=r"Skip.+missing.+specification ID.+$"):
+    with pytest.raises(EvaluationsError) as excinfo:
         opt.report(evaluations)
     assert len(opt.pending_configurations) == 0
+    assert re.match(r"1 evaluation.+rejected", excinfo.value.message)
+    assert excinfo.value.evaluations == [invalid_evaluation]
 
 
 def test_bohb_number_of_configs_and_fidelities_in_iterations():

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -34,14 +34,16 @@ def test_bohb_sequential():
     for i in range(3):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
-        opt.report_evaluation(es.create_evaluation(objectives={"loss": i}))
+        evaluation = es.create_evaluation(objectives={"loss": i})
+        opt.report_evaluations([evaluation])
     es = opt.get_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
         opt.get_evaluation_specification()
 
-    opt.report_evaluation(es.create_evaluation(objectives={"loss": 0.0}))
+    evaluation = es.create_evaluation(objectives={"loss": 0.0})
+    opt.report_evaluations([evaluation])
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()
@@ -70,7 +72,8 @@ def test_bohb_parallel():
     assert len(opt.pending_configurations) == 3
 
     for i, eval_spec in enumerate(eval_specs):
-        opt.report_evaluation(eval_spec.create_evaluation(objectives={"loss": i}))
+        evaluation = eval_spec.create_evaluation(objectives={"loss": i})
+        opt.report_evaluations([evaluation])
 
     assert len(opt.pending_configurations) == 0
 
@@ -137,20 +140,20 @@ def test_bohb_sequential_with_failed_evaluations(n_evaluations=16):
     for i in range(n_evaluations // 2):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
-
         if np.random.rand() < 0.8:
-            opt.report_evaluation(
-                es.create_evaluation(objectives={"loss": es.configuration["p1"]})
+            evaluation = es.create_evaluation(
+                objectives={"loss": es.configuration["p1"]}
             )
         else:
-            opt.report_evaluation(es.create_evaluation(objectives={"loss": None}))
+            evaluation = es.create_evaluation(objectives={"loss": None})
+        opt.report_evaluations([evaluation])
+
     for i in range(n_evaluations // 2, n_evaluations):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
-        opt.report_evaluation(
-            es.create_evaluation(objectives={"loss": es.configuration["p1"]})
-        )
+        evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
+        opt.report_evaluations([evaluation])
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()
@@ -183,23 +186,21 @@ def test_bohb_sequential_with_non_finite_losses(n_evaluations=16):
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
 
         if i // len(return_values) == 0:
-            opt.report_evaluation(
-                es.create_evaluation(objectives={"loss": es.configuration["p1"]})
+            evaluation = es.create_evaluation(
+                objectives={"loss": es.configuration["p1"]}
             )
         else:
-            opt.report_evaluation(
-                es.create_evaluation(
-                    result={"loss": return_values[i // len(return_values)]}
-                )
+            evaluation = es.create_evaluation(
+                result={"loss": return_values[i // len(return_values)]}
             )
+        opt.report_evaluations([evaluation])
 
     for i in range(n_evaluations // 2, n_evaluations):
         es = opt.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
-        opt.report_evaluation(
-            es.create_evaluation(objectives={"loss": es.configuration["p1"]})
-        )
+        evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
+        opt.report_evaluations([evaluation])
 
     with pytest.raises(OptimizationComplete):
         opt.get_evaluation_specification()

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -104,8 +104,8 @@ def test_bohb_report_as_batch():
         evaluation = es.create_evaluation(objectives={"loss": i})
         evaluations.append(evaluation)
 
-    # Add an evaluation _not_ created by the optimizer to see if it get's skipped
-    # and triggers a warning on reporting:
+    # Add an evaluation with missing specific details in the optimizer info to see if
+    # it get's skipped, raises an exception and gets included in the exception.
     invalid_evaluation = Evaluation(objectives={"loss": 42}, configuration={})
     evaluations.append(invalid_evaluation)
 

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -113,8 +113,8 @@ def test_bohb_report_as_batch():
     with pytest.raises(EvaluationsError) as excinfo:
         opt.report(evaluations)
     assert len(opt.pending_configurations) == 0
-    assert re.match(r"1 evaluation.+rejected", excinfo.value.message)
-    assert excinfo.value.evaluations == [invalid_evaluation]
+    assert excinfo.value.message.startswith("An error with one or more evaluation")
+    assert excinfo.value.evaluations_with_errors[0][0] == invalid_evaluation
 
 
 def test_bohb_number_of_configs_and_fidelities_in_iterations():

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -36,7 +36,7 @@ def test_hyperband_sequential():
         es = hb.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
-        hb.report_evaluations(evaluation)
+        hb.report(evaluation)
     es = hb.get_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
@@ -44,7 +44,7 @@ def test_hyperband_sequential():
         hb.get_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": i})
-    hb.report_evaluations(evaluation)
+    hb.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
         hb.get_evaluation_specification()
@@ -74,7 +74,7 @@ def test_hyperband_parallel():
 
     for i, es in enumerate(eval_specs):
         evaluation = es.create_evaluation(objectives={"loss": i})
-        hb.report_evaluations(evaluation)
+        hb.report(evaluation)
 
     assert len(hb.pending_configurations) == 0
 

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -35,14 +35,16 @@ def test_hyperband_sequential():
     for i in range(3):
         es = hb.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
-        hb.report_evaluation(es.create_evaluation(objectives={"loss": i}))
+        evaluation = es.create_evaluation(objectives={"loss": i})
+        hb.report_evaluations([evaluation])
     es = hb.get_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
         hb.get_evaluation_specification()
 
-    hb.report_evaluation(es.create_evaluation(objectives={"loss": i}))
+    evaluation = es.create_evaluation(objectives={"loss": i})
+    hb.report_evaluations([evaluation])
 
     with pytest.raises(OptimizationComplete):
         hb.get_evaluation_specification()
@@ -71,7 +73,8 @@ def test_hyperband_parallel():
     assert len(hb.pending_configurations) == 3
 
     for i, es in enumerate(eval_specs):
-        hb.report_evaluation(es.create_evaluation(objectives={"loss": i}))
+        evaluation = es.create_evaluation(objectives={"loss": i})
+        hb.report_evaluations([evaluation])
 
     assert len(hb.pending_configurations) == 0
 

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -36,7 +36,7 @@ def test_hyperband_sequential():
         es = hb.get_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
-        hb.report_evaluations([evaluation])
+        hb.report_evaluations(evaluation)
     es = hb.get_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
@@ -44,7 +44,7 @@ def test_hyperband_sequential():
         hb.get_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": i})
-    hb.report_evaluations([evaluation])
+    hb.report_evaluations(evaluation)
 
     with pytest.raises(OptimizationComplete):
         hb.get_evaluation_specification()
@@ -74,7 +74,7 @@ def test_hyperband_parallel():
 
     for i, es in enumerate(eval_specs):
         evaluation = es.create_evaluation(objectives={"loss": i})
-        hb.report_evaluations([evaluation])
+        hb.report_evaluations(evaluation)
 
     assert len(hb.pending_configurations) == 0
 

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -122,29 +122,26 @@ def test_sample_configurations():
     for _ in range(5):
         eval_spec = opt.get_evaluation_specification()
         assert not eval_spec.optimizer_info["model_based_pick"]
-        opt.report_evaluation(
-            eval_spec.create_evaluation(
-                objectives={"loss": eval_spec.configuration["x1"] ** 2}
-            )
+        evaluation = eval_spec.create_evaluation(
+            objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
+        opt.report_evaluations([evaluation])
 
     while eval_spec.optimizer_info["configuration_key"][0] == 0:
         eval_spec = opt.get_evaluation_specification()
-        opt.report_evaluation(
-            eval_spec.create_evaluation(
-                objectives={"loss": eval_spec.configuration["x1"] ** 2}
-            )
+        evaluation = eval_spec.create_evaluation(
+            objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
+        opt.report_evaluations([evaluation])
 
     while True:
         try:
             eval_spec = opt.get_evaluation_specification()
             assert eval_spec.optimizer_info["model_based_pick"]
-            opt.report_evaluation(
-                eval_spec.create_evaluation(
-                    objectives={"loss": eval_spec.configuration["x1"] ** 2}
-                )
+            evaluation = eval_spec.create_evaluation(
+                objectives={"loss": eval_spec.configuration["x1"] ** 2}
             )
+            opt.report_evaluations([evaluation])
         except OptimizationComplete:
             break
 

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -125,14 +125,14 @@ def test_sample_configurations():
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     while eval_spec.optimizer_info["configuration_key"][0] == 0:
         eval_spec = opt.get_evaluation_specification()
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
-        opt.report_evaluations(evaluation)
+        opt.report(evaluation)
 
     while True:
         try:
@@ -141,7 +141,7 @@ def test_sample_configurations():
             evaluation = eval_spec.create_evaluation(
                 objectives={"loss": eval_spec.configuration["x1"] ** 2}
             )
-            opt.report_evaluations(evaluation)
+            opt.report(evaluation)
         except OptimizationComplete:
             break
 

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -125,14 +125,14 @@ def test_sample_configurations():
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
-        opt.report_evaluations([evaluation])
+        opt.report_evaluations(evaluation)
 
     while eval_spec.optimizer_info["configuration_key"][0] == 0:
         eval_spec = opt.get_evaluation_specification()
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
-        opt.report_evaluations([evaluation])
+        opt.report_evaluations(evaluation)
 
     while True:
         try:
@@ -141,7 +141,7 @@ def test_sample_configurations():
             evaluation = eval_spec.create_evaluation(
                 objectives={"loss": eval_spec.configuration["x1"] ** 2}
             )
-            opt.report_evaluations([evaluation])
+            opt.report_evaluations(evaluation)
         except OptimizationComplete:
             break
 


### PR DESCRIPTION
This PR switches from reporting evaluations individually to allow reporting batches (lists) of evaluations, as discussed with @LGro in person. 

- Allows better performance in cases where we can fit a model with all evaluations in one run instead fitting it multiple times for every individual evaluation. @sfalkner : Would this be the case for e.g. BOHB? If yes, feel free to contribute an PR. :slightly_smiling_face:
- The `StagedIterationOptimizer` and the `sequential` optimization loop are not (yet?) adopted to leverage this functionality and just keep processing the evaluations individually.
- Individual evaluations still can be reported as a list of one item. (I propose to not allow `Union[List[Evaluation], Evaluation]` to keep the code and tests etc. more simple. What do you think?)



Signed-off-by: Buech Holger <holger.buech@de.bosch.com>