### PR TITLE
remove context from specification

### DIFF
--- a/blackboxopt/evaluation.py
+++ b/blackboxopt/evaluation.py
@@ -35,14 +35,6 @@ class EvaluationSpecification(Mapping[str, Any]):
         metadata={"Description": "Creation time of the evaluation specificiation."},
     )
 
-    context: Optional[Dict[str, Any]] = field(
-        default=None,
-        metadata={
-            "Description": "Contextual information is what you can determine but not "
-            + "influence, like the environmental temperature."
-        },
-    )
-
     def keys(self):
         return self.__dataclass_fields__.keys()  # pylint: disable=no-member
 

--- a/tests/evaluation_test.py
+++ b/tests/evaluation_test.py
@@ -88,7 +88,7 @@ def test_to_json():
     spec_json = spec.to_json()
     assert spec_json == (
         '{"configuration": {"p1": 1.2}, "settings": {"fidelity": 1.0}, '
-        '"optimizer_info": {"id": 123}, "created_unixtime": 1.0, "context": null}'
+        '"optimizer_info": {"id": 123}, "created_unixtime": 1.0}'
     )
 
     result = Evaluation(
@@ -98,7 +98,7 @@ def test_to_json():
     assert result_json == (
         '{"objectives": {"mse": 0.0, "r\\u00b2": 1.0}, "configuration": {"p1": 1.2}, '
         '"settings": {"fidelity": 1.0}, "optimizer_info": {"id": 123}, '
-        '"created_unixtime": 1.0, "context": null, "constraints": null, '
+        '"created_unixtime": 1.0, "constraints": null, '
         '"finished_unixtime": 2.0, "stacktrace": null, "user_info": null}'
     )
 


### PR DESCRIPTION
Since we discussed to allow context to individually fix parts of the search space on demand when requesting new evaluation specifications from the optimizer, I'd propose to remove the `context` attribute from the specification and rather leave it to the user to know what they fixed and the optimizer to represent that information as part of the `optimizer_info` attribute. What do you think?