### PR TITLE
replace time with datetime for unix timestamps

### DIFF
--- a/blackboxopt/evaluation.py
+++ b/blackboxopt/evaluation.py
@@ -4,12 +4,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import time
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from typing import Any, Dict, Mapping, Optional
 
 import numpy as np
+
+
+def _datetime_now_timestamp():
+    """Wrapper to allow use as default factory for dataclass fields."""
+    return datetime.now().timestamp()
 
 
 @dataclass
@@ -31,7 +36,7 @@ class EvaluationSpecification(Mapping[str, Any]):
     )
 
     created_unixtime: float = field(
-        default_factory=time.time,
+        default_factory=_datetime_now_timestamp,
         metadata={"Description": "Creation time of the evaluation specificiation."},
     )
 
@@ -146,7 +151,7 @@ class Evaluation(EvaluationSpecification, _EvaluationBase):
     )
 
     finished_unixtime: float = field(
-        default_factory=time.time,
+        default_factory=_datetime_now_timestamp,
         metadata={"Description": "Timestamp at completion of this evaluation."},
     )
 
@@ -177,7 +182,7 @@ class Evaluation(EvaluationSpecification, _EvaluationBase):
 
         if reset_created_unixtime:
             return EvaluationSpecification(
-                created_unixtime=time.time(), **eval_spec_kwargs
+                created_unixtime=_datetime_now_timestamp(), **eval_spec_kwargs
             )
 
         return EvaluationSpecification(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "1.0.6"
+version = "1.0.7"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Creates compatibility with `datetime` powered timestamp conversion, which creates six instead of seven decimal places for unix timestamps compared to `time.time()` and would thus cause equality checks to fail after conversion.

Signed-off-by: Grossberger Lukas (CR/PJ-AI-R32) <Lukas.Grossberger@de.bosch.com>