### PR TITLE
rename get_evaluation_specification to create_evaluation_specification

### DIFF
--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -149,7 +149,7 @@ class Optimizer(abc.ABC):
             self.search_space.seed(self.seed)
 
     @abc.abstractmethod
-    def create_evaluation_specification(self) -> EvaluationSpecification:
+    def generate_evaluation_specification(self) -> EvaluationSpecification:
         """Get next configuration and settings to evaluate.
 
         Raises:

--- a/blackboxopt/base.py
+++ b/blackboxopt/base.py
@@ -149,7 +149,7 @@ class Optimizer(abc.ABC):
             self.search_space.seed(self.seed)
 
     @abc.abstractmethod
-    def get_evaluation_specification(self) -> EvaluationSpecification:
+    def create_evaluation_specification(self) -> EvaluationSpecification:
         """Get next configuration and settings to evaluate.
 
         Raises:

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -150,7 +150,7 @@ def run_optimization_loop(
     while time.time() - start < timeout_s and n_eval_specs < _max_evaluations:
         if dask_scheduler.has_capacity():
             try:
-                eval_spec = optimizer.get_evaluation_specification()
+                eval_spec = optimizer.create_evaluation_specification()
                 dask_scheduler.submit(evaluation_function, eval_spec)
                 n_eval_specs += 1
                 continue

--- a/blackboxopt/optimization_loops/dask_distributed.py
+++ b/blackboxopt/optimization_loops/dask_distributed.py
@@ -150,7 +150,7 @@ def run_optimization_loop(
     while time.time() - start < timeout_s and n_eval_specs < _max_evaluations:
         if dask_scheduler.has_capacity():
             try:
-                eval_spec = optimizer.create_evaluation_specification()
+                eval_spec = optimizer.generate_evaluation_specification()
                 dask_scheduler.submit(evaluation_function, eval_spec)
                 n_eval_specs += 1
                 continue

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -69,7 +69,7 @@ def run_optimization_loop(
         num_evaluations += 1
 
         try:
-            evaluation_specification = optimizer.get_evaluation_specification()
+            evaluation_specification = optimizer.create_evaluation_specification()
             logger.debug(f"Evaluating: {evaluation_specification}")
 
             evaluation = evaluation_function_wrapper(

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -69,7 +69,7 @@ def run_optimization_loop(
         num_evaluations += 1
 
         try:
-            evaluation_specification = optimizer.create_evaluation_specification()
+            evaluation_specification = optimizer.generate_evaluation_specification()
             logger.debug(f"Evaluating: {evaluation_specification}")
 
             evaluation = evaluation_function_wrapper(

--- a/blackboxopt/optimization_loops/testing.py
+++ b/blackboxopt/optimization_loops/testing.py
@@ -34,9 +34,9 @@ def limit_with_max_evaluations(run_optimization_loop: Callable, loop_kwargs: dic
 
 def limit_with_loop_timeout(run_optimization_loop: Callable, loop_kwargs: dict):
     class SlowRandomSearch(RandomSearch):
-        def get_evaluation_specification(self) -> EvaluationSpecification:
+        def create_evaluation_specification(self) -> EvaluationSpecification:
             time.sleep(1)
-            return super().get_evaluation_specification()
+            return super().create_evaluation_specification()
 
     evaluations = run_optimization_loop(
         SlowRandomSearch(SPACE, [Objective("loss", False)], max_steps=10),

--- a/blackboxopt/optimization_loops/testing.py
+++ b/blackboxopt/optimization_loops/testing.py
@@ -34,9 +34,9 @@ def limit_with_max_evaluations(run_optimization_loop: Callable, loop_kwargs: dic
 
 def limit_with_loop_timeout(run_optimization_loop: Callable, loop_kwargs: dict):
     class SlowRandomSearch(RandomSearch):
-        def create_evaluation_specification(self) -> EvaluationSpecification:
+        def generate_evaluation_specification(self) -> EvaluationSpecification:
             time.sleep(1)
-            return super().create_evaluation_specification()
+            return super().generate_evaluation_specification()
 
     evaluations = run_optimization_loop(
         SlowRandomSearch(SPACE, [Objective("loss", False)], max_steps=10),

--- a/blackboxopt/optimizers/random_search.py
+++ b/blackboxopt/optimizers/random_search.py
@@ -37,7 +37,7 @@ class RandomSearch(MultiObjectiveOptimizer):
         self.max_steps: int = max_steps
         self.n_steps: int = 0
 
-    def get_evaluation_specification(self) -> EvaluationSpecification:
+    def create_evaluation_specification(self) -> EvaluationSpecification:
         """[summary]
 
         Raises:

--- a/blackboxopt/optimizers/random_search.py
+++ b/blackboxopt/optimizers/random_search.py
@@ -37,7 +37,7 @@ class RandomSearch(MultiObjectiveOptimizer):
         self.max_steps: int = max_steps
         self.n_steps: int = 0
 
-    def create_evaluation_specification(self) -> EvaluationSpecification:
+    def generate_evaluation_specification(self) -> EvaluationSpecification:
         """[summary]
 
         Raises:

--- a/blackboxopt/optimizers/staged/iteration.py
+++ b/blackboxopt/optimizers/staged/iteration.py
@@ -70,7 +70,7 @@ class StagedIteration:
         self.pending_evaluations: Dict[UUID, int] = {}
         self.finished = False
 
-    def create_evaluation_specification(self) -> Optional[EvaluationSpecification]:
+    def generate_evaluation_specification(self) -> Optional[EvaluationSpecification]:
         """Pick the next evaluation specification with a budget i.e. fidelity to run.
 
         Returns:
@@ -105,7 +105,7 @@ class StagedIteration:
             )
             self.evaluation_data[self.current_stage].append(Datum(conf_key, "QUEUED"))
             # To understand recursion, you first must understand recursion :)
-            return self.create_evaluation_specification()
+            return self.generate_evaluation_specification()
 
         # at this point there are pending evaluations and this iteration has to wait
         return None

--- a/blackboxopt/optimizers/staged/iteration.py
+++ b/blackboxopt/optimizers/staged/iteration.py
@@ -70,7 +70,7 @@ class StagedIteration:
         self.pending_evaluations: Dict[UUID, int] = {}
         self.finished = False
 
-    def get_evaluation_specification(self) -> Optional[EvaluationSpecification]:
+    def create_evaluation_specification(self) -> Optional[EvaluationSpecification]:
         """Pick the next evaluation specification with a budget i.e. fidelity to run.
 
         Returns:
@@ -105,7 +105,7 @@ class StagedIteration:
             )
             self.evaluation_data[self.current_stage].append(Datum(conf_key, "QUEUED"))
             # To understand recursion, you first must understand recursion :)
-            return self.get_evaluation_specification()
+            return self.create_evaluation_specification()
 
         # at this point there are pending evaluations and this iteration has to wait
         return None

--- a/blackboxopt/optimizers/staged/optimizer.py
+++ b/blackboxopt/optimizers/staged/optimizer.py
@@ -68,7 +68,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         idx = self.evaluation_uuid_to_iteration.pop(str(evaluation_specification_id))
         self.iterations[idx].digest_evaluation(evaluation_specification_id, evaluation)
 
-    def get_evaluation_specification(self) -> EvaluationSpecification:
+    def create_evaluation_specification(self) -> EvaluationSpecification:
         """Get next configuration and settings to evaluate.
 
         Raises:
@@ -80,7 +80,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         # check if any of the already active iterations returns a configuration and
         # simply return that
         for idx, iteration in enumerate(self.iterations):
-            es = iteration.get_evaluation_specification()
+            es = iteration.create_evaluation_specification()
 
             if es is not None:
                 self.evaluation_uuid_to_iteration[str(es.optimizer_info["id"])] = idx
@@ -91,7 +91,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         # ask it for a configuration
         if len(self.iterations) < self.num_iterations:
             self.iterations.append(self._create_new_iteration(len(self.iterations)))
-            es = self.iterations[-1].get_evaluation_specification()
+            es = self.iterations[-1].create_evaluation_specification()
             self.evaluation_uuid_to_iteration[str(es.optimizer_info["id"])] = (
                 len(self.iterations) - 1
             )

--- a/blackboxopt/optimizers/staged/optimizer.py
+++ b/blackboxopt/optimizers/staged/optimizer.py
@@ -68,7 +68,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         idx = self.evaluation_uuid_to_iteration.pop(str(evaluation_specification_id))
         self.iterations[idx].digest_evaluation(evaluation_specification_id, evaluation)
 
-    def create_evaluation_specification(self) -> EvaluationSpecification:
+    def generate_evaluation_specification(self) -> EvaluationSpecification:
         """Get next configuration and settings to evaluate.
 
         Raises:
@@ -80,7 +80,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         # check if any of the already active iterations returns a configuration and
         # simply return that
         for idx, iteration in enumerate(self.iterations):
-            es = iteration.create_evaluation_specification()
+            es = iteration.generate_evaluation_specification()
 
             if es is not None:
                 self.evaluation_uuid_to_iteration[str(es.optimizer_info["id"])] = idx
@@ -91,7 +91,7 @@ class StagedIterationOptimizer(SingleObjectiveOptimizer):
         # ask it for a configuration
         if len(self.iterations) < self.num_iterations:
             self.iterations.append(self._create_new_iteration(len(self.iterations)))
-            es = self.iterations[-1].create_evaluation_specification()
+            es = self.iterations[-1].generate_evaluation_specification()
             self.evaluation_uuid_to_iteration[str(es.optimizer_info["id"])] = (
                 len(self.iterations) - 1
             )

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -69,7 +69,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         objectives=[Objective("loss", False), Objective("score", True)],
     )
 
-    eval_spec = optimizer.get_evaluation_specification()
+    eval_spec = optimizer.create_evaluation_specification()
 
     if issubclass(optimizer_class, MultiObjectiveOptimizer):
         evaluation = eval_spec.create_evaluation(
@@ -82,7 +82,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     for _ in range(n_max_evaluations):
 
         try:
-            eval_spec = optimizer.get_evaluation_specification()
+            eval_spec = optimizer.create_evaluation_specification()
         except OptimizationComplete:
             break
 
@@ -125,10 +125,10 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
             objectives=[Objective("loss", False)],
         )
 
-        es1 = opt.get_evaluation_specification()
+        es1 = opt.create_evaluation_specification()
         evaluation1 = es1.create_evaluation(objectives={"loss": 0.42})
         opt.report(evaluation1)
-        es2 = opt.get_evaluation_specification()
+        es2 = opt.create_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
 
@@ -161,7 +161,7 @@ def handles_reporting_evaluations_list(optimizer_class, optimizer_kwargs: dict) 
     )
     evaluations = []
     for _ in range(3):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         evaluation = es.create_evaluation(objectives={"loss": 0.42})
         evaluations.append(evaluation)
 
@@ -192,9 +192,9 @@ def raises_evaluation_error_when_reporting_unknown_objective(
         objective=Objective("loss", False),
         objectives=[Objective("loss", False)],
     )
-    es_1 = opt.get_evaluation_specification()
-    es_2 = opt.get_evaluation_specification()
-    es_3 = opt.get_evaluation_specification()
+    es_1 = opt.create_evaluation_specification()
+    es_2 = opt.create_evaluation_specification()
+    es_3 = opt.create_evaluation_specification()
 
     # NOTE: The following is not using pytest.raises because this would add pytest as
     #       a regular dependency to blackboxopt.

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -69,7 +69,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         objectives=[Objective("loss", False), Objective("score", True)],
     )
 
-    eval_spec = optimizer.create_evaluation_specification()
+    eval_spec = optimizer.generate_evaluation_specification()
 
     if issubclass(optimizer_class, MultiObjectiveOptimizer):
         evaluation = eval_spec.create_evaluation(
@@ -82,7 +82,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     for _ in range(n_max_evaluations):
 
         try:
-            eval_spec = optimizer.create_evaluation_specification()
+            eval_spec = optimizer.generate_evaluation_specification()
         except OptimizationComplete:
             break
 
@@ -125,10 +125,10 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
             objectives=[Objective("loss", False)],
         )
 
-        es1 = opt.create_evaluation_specification()
+        es1 = opt.generate_evaluation_specification()
         evaluation1 = es1.create_evaluation(objectives={"loss": 0.42})
         opt.report(evaluation1)
-        es2 = opt.create_evaluation_specification()
+        es2 = opt.generate_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
 
@@ -161,7 +161,7 @@ def handles_reporting_evaluations_list(optimizer_class, optimizer_kwargs: dict) 
     )
     evaluations = []
     for _ in range(3):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         evaluation = es.create_evaluation(objectives={"loss": 0.42})
         evaluations.append(evaluation)
 
@@ -192,9 +192,9 @@ def raises_evaluation_error_when_reporting_unknown_objective(
         objective=Objective("loss", False),
         objectives=[Objective("loss", False)],
     )
-    es_1 = opt.create_evaluation_specification()
-    es_2 = opt.create_evaluation_specification()
-    es_3 = opt.create_evaluation_specification()
+    es_1 = opt.generate_evaluation_specification()
+    es_2 = opt.generate_evaluation_specification()
+    es_3 = opt.generate_evaluation_specification()
 
     # NOTE: The following is not using pytest.raises because this would add pytest as
     #       a regular dependency to blackboxopt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "1.0.11"
+version = "1.1.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/optimization_loops/dask_distributed_test.py
+++ b/tests/optimization_loops/dask_distributed_test.py
@@ -60,7 +60,7 @@ def test_restarting_workers(tmpdir):
     opt = RandomSearch(space, objectives, max_steps=4)
 
     # create an evaluation spec that causes the worker to unexpectedly stop
-    eval_spec = opt.get_evaluation_specification()
+    eval_spec = opt.create_evaluation_specification()
     eval_spec.configuration["exit"] = True
     scheduler.submit(evaluation_function_cause_worker_restart, eval_spec)
     res = scheduler.check_for_results(20)

--- a/tests/optimization_loops/dask_distributed_test.py
+++ b/tests/optimization_loops/dask_distributed_test.py
@@ -60,7 +60,7 @@ def test_restarting_workers(tmpdir):
     opt = RandomSearch(space, objectives, max_steps=4)
 
     # create an evaluation spec that causes the worker to unexpectedly stop
-    eval_spec = opt.create_evaluation_specification()
+    eval_spec = opt.generate_evaluation_specification()
     eval_spec.configuration["exit"] = True
     scheduler.submit(evaluation_function_cause_worker_restart, eval_spec)
     res = scheduler.check_for_results(20)

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -33,21 +33,21 @@ def test_sequential():
     )
 
     for i in range(3):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
         opt.report(evaluation)
-    es = opt.create_evaluation_specification()
+    es = opt.generate_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": 0.0})
     opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
 
 def test_parallel():
@@ -66,7 +66,7 @@ def test_parallel():
     for i in range(3):
         # note, this test doesn't return results immediately, but has 3 concurrently
         # 'pending` evaluations.
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         eval_specs.append(es)
 
@@ -78,11 +78,11 @@ def test_parallel():
 
     assert len(opt.pending_configurations) == 0
 
-    es = opt.create_evaluation_specification()
+    es = opt.generate_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     for i in range(2):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (1, 0, i)
 
 
@@ -99,7 +99,7 @@ def test_report_as_batch():
 
     evaluations = []
     for i in range(3):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         evaluation = es.create_evaluation(objectives={"loss": i})
         evaluations.append(evaluation)
 
@@ -169,7 +169,7 @@ def test_sequential_with_failed_evaluations(n_evaluations=16):
     )
 
     for i in range(n_evaluations // 2):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         if np.random.rand() < 0.8:
             evaluation = es.create_evaluation(
@@ -180,14 +180,14 @@ def test_sequential_with_failed_evaluations(n_evaluations=16):
         opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
         opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
 
 def test_sequential_with_non_finite_losses(n_evaluations=16):
@@ -213,7 +213,7 @@ def test_sequential_with_non_finite_losses(n_evaluations=16):
     ]
 
     for i in range(n_evaluations // 2):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
 
         if i // len(return_values) == 0:
@@ -227,14 +227,14 @@ def test_sequential_with_non_finite_losses(n_evaluations=16):
         opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
         opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
 
 def test_with_none_min_samples_in_model():
@@ -264,7 +264,7 @@ def test_minimize_quadratic():
 
     evals = []
     for _ in range(9 + 3 + 1):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         e = es.create_evaluation(objectives={"loss": es.configuration["p1"] ** 2})
         evals.append(e)
         opt.report(e)
@@ -291,7 +291,7 @@ def test_maximize_quadratic():
 
     evals = []
     for _ in range(9 + 3 + 1):
-        es = opt.create_evaluation_specification()
+        es = opt.generate_evaluation_specification()
         e = es.create_evaluation(objectives={"score": -(es.configuration["p1"] ** 2)})
         evals.append(e)
         opt.report(e)

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -33,21 +33,21 @@ def test_sequential():
     )
 
     for i in range(3):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
         opt.report(evaluation)
-    es = opt.get_evaluation_specification()
+    es = opt.create_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": 0.0})
     opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
 
 def test_parallel():
@@ -66,7 +66,7 @@ def test_parallel():
     for i in range(3):
         # note, this test doesn't return results immediately, but has 3 concurrently
         # 'pending` evaluations.
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         eval_specs.append(es)
 
@@ -78,11 +78,11 @@ def test_parallel():
 
     assert len(opt.pending_configurations) == 0
 
-    es = opt.get_evaluation_specification()
+    es = opt.create_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     for i in range(2):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (1, 0, i)
 
 
@@ -99,7 +99,7 @@ def test_report_as_batch():
 
     evaluations = []
     for i in range(3):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         evaluation = es.create_evaluation(objectives={"loss": i})
         evaluations.append(evaluation)
 
@@ -169,7 +169,7 @@ def test_sequential_with_failed_evaluations(n_evaluations=16):
     )
 
     for i in range(n_evaluations // 2):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         if np.random.rand() < 0.8:
             evaluation = es.create_evaluation(
@@ -180,14 +180,14 @@ def test_sequential_with_failed_evaluations(n_evaluations=16):
         opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
         opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
 
 def test_sequential_with_non_finite_losses(n_evaluations=16):
@@ -213,7 +213,7 @@ def test_sequential_with_non_finite_losses(n_evaluations=16):
     ]
 
     for i in range(n_evaluations // 2):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
 
         if i // len(return_values) == 0:
@@ -227,14 +227,14 @@ def test_sequential_with_non_finite_losses(n_evaluations=16):
         opt.report(evaluation)
 
     for i in range(n_evaluations // 2, n_evaluations):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (i, 0, 0)
         assert es.optimizer_info["model_based_pick"]
         evaluation = es.create_evaluation(objectives={"loss": es.configuration["p1"]})
         opt.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
 
 def test_with_none_min_samples_in_model():
@@ -264,7 +264,7 @@ def test_minimize_quadratic():
 
     evals = []
     for _ in range(9 + 3 + 1):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         e = es.create_evaluation(objectives={"loss": es.configuration["p1"] ** 2})
         evals.append(e)
         opt.report(e)
@@ -291,7 +291,7 @@ def test_maximize_quadratic():
 
     evals = []
     for _ in range(9 + 3 + 1):
-        es = opt.get_evaluation_specification()
+        es = opt.create_evaluation_specification()
         e = es.create_evaluation(objectives={"score": -(es.configuration["p1"] ** 2)})
         evals.append(e)
         opt.report(e)

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -33,21 +33,21 @@ def test_hyperband_sequential():
     )
 
     for i in range(3):
-        es = hb.get_evaluation_specification()
+        es = hb.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
         hb.report(evaluation)
-    es = hb.get_evaluation_specification()
+    es = hb.create_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
-        hb.get_evaluation_specification()
+        hb.create_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": i})
     hb.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        hb.get_evaluation_specification()
+        hb.create_evaluation_specification()
 
 
 def test_hyperband_parallel():
@@ -66,7 +66,7 @@ def test_hyperband_parallel():
     for i in range(3):
         # note, this test doesn't return results immediately, but has 3 concurrently
         # 'pending` evaluations.
-        es = hb.get_evaluation_specification()
+        es = hb.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         eval_specs.append(es)
 
@@ -78,11 +78,11 @@ def test_hyperband_parallel():
 
     assert len(hb.pending_configurations) == 0
 
-    es = hb.get_evaluation_specification()
+    es = hb.create_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     for i in range(2):
-        es = hb.get_evaluation_specification()
+        es = hb.create_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (1, 0, i)
 
 

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -33,21 +33,21 @@ def test_hyperband_sequential():
     )
 
     for i in range(3):
-        es = hb.create_evaluation_specification()
+        es = hb.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         evaluation = es.create_evaluation(objectives={"loss": i})
         hb.report(evaluation)
-    es = hb.create_evaluation_specification()
+    es = hb.generate_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     with pytest.raises(OptimizerNotReady):
-        hb.create_evaluation_specification()
+        hb.generate_evaluation_specification()
 
     evaluation = es.create_evaluation(objectives={"loss": i})
     hb.report(evaluation)
 
     with pytest.raises(OptimizationComplete):
-        hb.create_evaluation_specification()
+        hb.generate_evaluation_specification()
 
 
 def test_hyperband_parallel():
@@ -66,7 +66,7 @@ def test_hyperband_parallel():
     for i in range(3):
         # note, this test doesn't return results immediately, but has 3 concurrently
         # 'pending` evaluations.
-        es = hb.create_evaluation_specification()
+        es = hb.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (0, 0, i)
         eval_specs.append(es)
 
@@ -78,11 +78,11 @@ def test_hyperband_parallel():
 
     assert len(hb.pending_configurations) == 0
 
-    es = hb.create_evaluation_specification()
+    es = hb.generate_evaluation_specification()
     assert es.optimizer_info["configuration_key"] == (0, 0, 0)
 
     for i in range(2):
-        es = hb.create_evaluation_specification()
+        es = hb.generate_evaluation_specification()
         assert es.optimizer_info["configuration_key"] == (1, 0, i)
 
 

--- a/tests/optimizers/random_search_test.py
+++ b/tests/optimizers/random_search_test.py
@@ -25,10 +25,10 @@ def test_max_steps_randomsearch():
     opt = RandomSearch(SPACE, [Objective("loss", False)], max_steps=MAX_STEPS)
 
     for _ in range(MAX_STEPS):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
     with pytest.raises(OptimizationComplete):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()
 
     with pytest.raises(OptimizationComplete):
-        opt.get_evaluation_specification()
+        opt.create_evaluation_specification()

--- a/tests/optimizers/random_search_test.py
+++ b/tests/optimizers/random_search_test.py
@@ -25,10 +25,10 @@ def test_max_steps_randomsearch():
     opt = RandomSearch(SPACE, [Objective("loss", False)], max_steps=MAX_STEPS)
 
     for _ in range(MAX_STEPS):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
     with pytest.raises(OptimizationComplete):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()
 
     with pytest.raises(OptimizationComplete):
-        opt.create_evaluation_specification()
+        opt.generate_evaluation_specification()

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -120,7 +120,7 @@ def test_sample_configurations():
     )
 
     for _ in range(5):
-        eval_spec = opt.get_evaluation_specification()
+        eval_spec = opt.create_evaluation_specification()
         assert not eval_spec.optimizer_info["model_based_pick"]
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
@@ -128,7 +128,7 @@ def test_sample_configurations():
         opt.report(evaluation)
 
     while eval_spec.optimizer_info["configuration_key"][0] == 0:
-        eval_spec = opt.get_evaluation_specification()
+        eval_spec = opt.create_evaluation_specification()
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
@@ -136,7 +136,7 @@ def test_sample_configurations():
 
     while True:
         try:
-            eval_spec = opt.get_evaluation_specification()
+            eval_spec = opt.create_evaluation_specification()
             assert eval_spec.optimizer_info["model_based_pick"]
             evaluation = eval_spec.create_evaluation(
                 objectives={"loss": eval_spec.configuration["x1"] ** 2}

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -120,7 +120,7 @@ def test_sample_configurations():
     )
 
     for _ in range(5):
-        eval_spec = opt.create_evaluation_specification()
+        eval_spec = opt.generate_evaluation_specification()
         assert not eval_spec.optimizer_info["model_based_pick"]
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
@@ -128,7 +128,7 @@ def test_sample_configurations():
         opt.report(evaluation)
 
     while eval_spec.optimizer_info["configuration_key"][0] == 0:
-        eval_spec = opt.create_evaluation_specification()
+        eval_spec = opt.generate_evaluation_specification()
         evaluation = eval_spec.create_evaluation(
             objectives={"loss": eval_spec.configuration["x1"] ** 2}
         )
@@ -136,7 +136,7 @@ def test_sample_configurations():
 
     while True:
         try:
-            eval_spec = opt.create_evaluation_specification()
+            eval_spec = opt.generate_evaluation_specification()
             assert eval_spec.optimizer_info["model_based_pick"]
             evaluation = eval_spec.create_evaluation(
                 objectives={"loss": eval_spec.configuration["x1"] ** 2}

--- a/tests/optimizers/staged/iteration_test.py
+++ b/tests/optimizers/staged/iteration_test.py
@@ -57,7 +57,7 @@ def test_staged_iteration_get_and_digest_configuration():
 
     eval_specs = []
     for i in range(n_eval_specs - 1):
-        eval_specs.append(iteration.get_evaluation_specification())
+        eval_specs.append(iteration.create_evaluation_specification())
         assert eval_specs[-1].configuration["value"] == i
         iteration.digest_evaluation(
             eval_specs[-1].optimizer_info["id"],
@@ -68,12 +68,12 @@ def test_staged_iteration_get_and_digest_configuration():
 
     # get the last config in this stage
     i = n_eval_specs - 1
-    eval_specs.append(iteration.get_evaluation_specification())
+    eval_specs.append(iteration.create_evaluation_specification())
     assert eval_specs[-1].configuration["value"] == i
     assert iteration.current_stage == 0
     # make sure no configuration is returned when all configurations in a stage have
     # been queried, but not all have finished
-    assert iteration.get_evaluation_specification() is None
+    assert iteration.create_evaluation_specification() is None
 
     # digest it and see that the next stage is reached
     iteration.digest_evaluation(
@@ -83,14 +83,14 @@ def test_staged_iteration_get_and_digest_configuration():
     assert iteration.current_stage == 1
     assert not iteration.finished
 
-    final_eval_spec = iteration.get_evaluation_specification()
+    final_eval_spec = iteration.create_evaluation_specification()
     assert final_eval_spec.configuration["value"] == 0
     iteration.digest_evaluation(
         final_eval_spec.optimizer_info["id"],
         final_eval_spec.create_evaluation(objectives={"loss": 0.0}),
     )
     assert iteration.finished
-    assert iteration.get_evaluation_specification() is None
+    assert iteration.create_evaluation_specification() is None
 
 
 @pytest.mark.timeout(1)
@@ -109,7 +109,7 @@ def test_staged_iteration_get_and_digest_configuration_with_crashes():
 
     eval_specs = []
     for i in range(n_eval_specs):
-        eval_specs.append(iteration.get_evaluation_specification())
+        eval_specs.append(iteration.create_evaluation_specification())
         assert eval_specs[-1].configuration["value"] == i
 
     for i in range(n_eval_specs - 1):
@@ -130,7 +130,7 @@ def test_staged_iteration_get_and_digest_configuration_with_crashes():
     # make sure the crashed config is not promoted and a new one is sampled instead
     eval_specs = []
     for i in range(n_eval_specs):
-        eval_specs.append(iteration.get_evaluation_specification())
+        eval_specs.append(iteration.create_evaluation_specification())
 
     assert all([c.configuration["value"] == i for i, c in enumerate(eval_specs[:-1])])
     assert eval_specs[-1].configuration["value"] == n_eval_specs

--- a/tests/optimizers/staged/iteration_test.py
+++ b/tests/optimizers/staged/iteration_test.py
@@ -57,7 +57,7 @@ def test_staged_iteration_get_and_digest_configuration():
 
     eval_specs = []
     for i in range(n_eval_specs - 1):
-        eval_specs.append(iteration.create_evaluation_specification())
+        eval_specs.append(iteration.generate_evaluation_specification())
         assert eval_specs[-1].configuration["value"] == i
         iteration.digest_evaluation(
             eval_specs[-1].optimizer_info["id"],
@@ -68,12 +68,12 @@ def test_staged_iteration_get_and_digest_configuration():
 
     # get the last config in this stage
     i = n_eval_specs - 1
-    eval_specs.append(iteration.create_evaluation_specification())
+    eval_specs.append(iteration.generate_evaluation_specification())
     assert eval_specs[-1].configuration["value"] == i
     assert iteration.current_stage == 0
     # make sure no configuration is returned when all configurations in a stage have
     # been queried, but not all have finished
-    assert iteration.create_evaluation_specification() is None
+    assert iteration.generate_evaluation_specification() is None
 
     # digest it and see that the next stage is reached
     iteration.digest_evaluation(
@@ -83,14 +83,14 @@ def test_staged_iteration_get_and_digest_configuration():
     assert iteration.current_stage == 1
     assert not iteration.finished
 
-    final_eval_spec = iteration.create_evaluation_specification()
+    final_eval_spec = iteration.generate_evaluation_specification()
     assert final_eval_spec.configuration["value"] == 0
     iteration.digest_evaluation(
         final_eval_spec.optimizer_info["id"],
         final_eval_spec.create_evaluation(objectives={"loss": 0.0}),
     )
     assert iteration.finished
-    assert iteration.create_evaluation_specification() is None
+    assert iteration.generate_evaluation_specification() is None
 
 
 @pytest.mark.timeout(1)
@@ -109,7 +109,7 @@ def test_staged_iteration_get_and_digest_configuration_with_crashes():
 
     eval_specs = []
     for i in range(n_eval_specs):
-        eval_specs.append(iteration.create_evaluation_specification())
+        eval_specs.append(iteration.generate_evaluation_specification())
         assert eval_specs[-1].configuration["value"] == i
 
     for i in range(n_eval_specs - 1):
@@ -130,7 +130,7 @@ def test_staged_iteration_get_and_digest_configuration_with_crashes():
     # make sure the crashed config is not promoted and a new one is sampled instead
     eval_specs = []
     for i in range(n_eval_specs):
-        eval_specs.append(iteration.create_evaluation_specification())
+        eval_specs.append(iteration.generate_evaluation_specification())
 
     assert all([c.configuration["value"] == i for i, c in enumerate(eval_specs[:-1])])
     assert eval_specs[-1].configuration["value"] == n_eval_specs


### PR DESCRIPTION
For UX reasons, it makes sense to change away from `get_`, but instead of the now introduced `create_` we could also go for `propose_` if you prefer that, @sfalkner / @dynobo.

Signed-off-by: Grossberger Lukas (CR/PJ-AI-R32) <Lukas.Grossberger@de.bosch.com>