### PR TITLE
Feature/bohb ordinal parameters

### DIFF
--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -26,10 +26,11 @@ def _initialize_optimizer(
     seed=42,
 ) -> Optimizer:
     space = ps.ParameterSpace()
-    space.add(ps.IntegerParameter("p1", bounds=[1, 32], transformation="log"))
-    space.add(ps.ContinuousParameter("p2", [-2, 2]))
-    space.add(ps.ContinuousParameter("p3", [0, 1]))
-    space.add(ps.CategoricalParameter("p4", [True, False]))
+    space.add(ps.IntegerParameter("p1", bounds=(1, 32), transformation="log"))
+    space.add(ps.ContinuousParameter("p2", (-2, 2)))
+    space.add(ps.ContinuousParameter("p3", (0, 1)))
+    space.add(ps.CategoricalParameter("p4", (True, False)))
+    space.add(ps.OrdinalParameter("p5", ("small", "medium", "large")))
 
     if issubclass(optimizer_class, MultiObjectiveOptimizer):
         return optimizer_class(space, objectives, seed=seed, **optimizer_kwargs)

--- a/tests/optimizers/staged/bohb_test.py
+++ b/tests/optimizers/staged/bohb_test.py
@@ -91,20 +91,6 @@ def test_sample_around(n_samples=128):
         assert space.from_numerical(another_sample)
 
 
-def test_fail_with_ordinal_parameters():
-    space = ps.ParameterSpace()
-    space.add(ps.OrdinalParameter("o1", ["foo", "bar", "baz"]))
-
-    with pytest.raises(RuntimeError):
-        BOHB(
-            space,
-            Objective("loss", False),
-            min_fidelity=1.0,
-            max_fidelity=3.0,
-            num_iterations=3,
-        )
-
-
 def test_sample_configurations():
     space = ps.ParameterSpace()
     space.add(ps.ContinuousParameter("x1", [-1, 1]))


### PR DESCRIPTION
@sfalkner, this is an attempt to map ordinal parameters to integer parameters for all BOHB internal operations (sampling and iterations) despite that it would only be needed in the `BOHBSampler`, but I found the implementation proposed here to be the least invasive and easiest to read. Also, I wouldn't expect a negative effect on the iterations' racing performance since a numerical representation is used there anyhow. Let me know what you think :relaxed: 

FYI: @aeivazi, @dynobo 