### PR TITLE
fix mask pareto efficient visualization util

### DIFF
--- a/blackboxopt/visualizations/utils.py
+++ b/blackboxopt/visualizations/utils.py
@@ -180,30 +180,15 @@ def mask_pareto_efficient(costs: np.ndarray):
     NOTE: The result marks multiple occurrences of the same point all as pareto
     efficient.
     """
-    # for each iteration check the conditions as follows...
-    # mark an entry inefficient when either one of the following is fulfilled:
-    #   - one objective value in costs is greater/worse and one other is equal
-    #   - all objective values in costs is greater/worse
-    # which means in turn that the pareto efficient ones satisfy one of:
-    #   - all entries equal
-    #   - one objective value in costs is greater/worse and one is smaller/better
-    #   - all objective values in costs is smaller/better
     is_efficient = np.ones(costs.shape[0], dtype=bool)
     for i, c in enumerate(costs):
         if not is_efficient[i]:
             continue
 
-        all_worse = np.all(costs[is_efficient] > c, axis=1)
-
-        at_least_one_worse = np.any(costs[is_efficient] > c, axis=1)
-        some_equal = np.any(costs[is_efficient] == c, axis=1)
-        some_equal_others_worse = np.logical_and(some_equal, at_least_one_worse)
-
-        is_efficient[is_efficient] = ~np.logical_or(all_worse, some_equal_others_worse)
-
-        # One should not result in onself becoming inefficient, which might happen for
-        # numerical reasons (unclear if this safeguard is necessary)
-        is_efficient[i] = True
+        # Keep any point with a lower cost or when they are the same
+        efficient = np.any(costs[is_efficient] < c, axis=1)
+        duplicates = np.all(costs[is_efficient] == c, axis=1)
+        is_efficient[is_efficient] = np.logical_or(efficient, duplicates)
 
     return is_efficient
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.3.2"
+version = "4.3.3"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -225,6 +225,7 @@ def test_mask_pareto_efficient():
             [3.1, 1.1],
             [0.1, 1.0],
             [0.0, 1.1],
+            [-1.0, 2.0],
         ]
     )
     pareto_efficient = mask_pareto_efficient(evals)
@@ -236,6 +237,7 @@ def test_mask_pareto_efficient():
     assert not pareto_efficient[4]
     assert not pareto_efficient[5]
     assert not pareto_efficient[6]
+    assert pareto_efficient[7]
 
 
 def test_prepare_for_multi_objective_visualization_handles_score_objectives():

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -216,7 +216,6 @@ def test_multi_objective_visualization_without_fidelities():
 
 
 def test_mask_pareto_efficient():
-
     evals = np.array(
         [
             [0.0, 1.0],
@@ -224,15 +223,19 @@ def test_mask_pareto_efficient():
             [0.0, 1.0],
             [1.0, 0.0],
             [3.1, 1.1],
+            [0.1, 1.0],
+            [0.0, 1.1],
         ]
     )
     pareto_efficient = mask_pareto_efficient(evals)
-    assert len(pareto_efficient) == 5
+    assert len(pareto_efficient) == evals.shape[0]
     assert pareto_efficient[0]
     assert not pareto_efficient[1]
     assert pareto_efficient[2]
     assert pareto_efficient[3]
     assert not pareto_efficient[4]
+    assert not pareto_efficient[5]
+    assert not pareto_efficient[6]
 
 
 def test_prepare_for_multi_objective_visualization_handles_score_objectives():


### PR DESCRIPTION
We had the issue where points were considered pareto efficient when they were "on the pareto front" despite not being on a corner of the pareto front. This PR extends the test with two cases that failed before and are fixed now with what is hopefully also a more readable despite somewhat more complex implementation.