### PR TITLE
test on all supported python versions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,8 +1,8 @@
 name: ci-cd-pipeline
 
-on: [push, pull_request]
+on: push
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-20.04
     container: python:3.8-slim
     steps:
@@ -35,11 +35,25 @@ jobs:
         continue-on-error: true
         if: always()
         run: poetry run pydocstyle
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ["python:3.7", "python:3.8", "python:3.9"]
+    container: ${{ matrix.python-version }}-slim
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --extras "all"
       - name: Run tests
         if: always()
         run: poetry run pytest
   deploy:
-    needs: test
+    needs: [lint, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     container: python:3.8-slim
@@ -55,7 +69,7 @@ jobs:
           poetry config pypi-token.pypi $PYPI_TOKEN
           poetry publish --build
   docs:
-    needs: test
+    needs: [lint, test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = ">=3.7.1,<3.10"
 parameterspace = "^0.7.2"
 numpy = {version = "^1.20.1", optional = true}
 plotly = {version = "^4.14.3", optional = true}


### PR DESCRIPTION
Given that we promise to support different Python versions, let's test that we actually do.
To that end this PR separates linting from testing and introduces a test matrix with Python versions 3.7, 3.8, and 3.9. We also explicitly exclude the yet unsupported 3.10 now in the pyproject.toml

FYI: @attilareiss and @sfalkner 

Signed-off-by: Grossberger Lukas (CR/PJ-AI-R32) <Lukas.Grossberger@de.bosch.com>