### PR TITLE
Add parallel coordinates plot

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.4.2"
+__version__ = "4.4.3"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -6,6 +6,7 @@
 import datetime
 import itertools
 import warnings
+from collections import Counter
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -237,6 +238,14 @@ def parallel_coordinate_plot_parameters(
     # If no columns are specified, use all:
     if not columns:
         columns = df.columns.to_list()
+
+    ambigious_columns = [k for k, v in Counter(df[columns].columns).items() if v > 1]
+    if ambigious_columns:
+        raise ValueError(
+            "All columns to plot must have a unique name, but those are ambigious: "
+            + f"{ambigious_columns}. Either rename parameters/settings/objective to "
+            + "be unique or provide only the unambigious ones as `columns` argument."
+        )
 
     # Prepare a coordinate (vertical line) for every column
     coordinates = []

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -212,9 +212,9 @@ def parallel_coordinate_plot_parameters(
         columns: Names of columns to show. Can contain parameter names, objective names
             and settings keys. If `None`, all parameters, objectives and settings are
             displayed.
-        color_by: Parameter name, objective name, settings key. The corresponding column
-            will be shown at the very right, it's value will be used for the color
-            scale. If `None`, all lines have the same color.
+        color_by: Parameter name, objective name or settings key. The corresponding
+            column will be shown at the very right, it's value will be used for the
+            color scale. If `None`, all lines have the same color.
 
     Returns:
         Plotly figure
@@ -230,14 +230,24 @@ def parallel_coordinate_plot_parameters(
     df = evaluations_to_df(evaluations)
 
     # Drop unused columns and indices
-    df = df[["configuration", "settings", "objectives"]]
+    if "settings" in df.columns:
+        df = df[["configuration", "settings", "objectives"]]
+        settings_cols = df["settings"].columns.to_list()
+    else:
+        df = df[["configuration", "objectives"]]
+        settings_cols = []
     objective_cols = df["objectives"].columns.to_list()
-    settings_cols = df["settings"].columns.to_list()
     df = df.droplevel(0, axis=1)
 
     # If no columns are specified, use all:
     if not columns:
         columns = df.columns.to_list()
+
+    if color_by and color_by not in columns:
+        raise ValueError(
+            f"Unknown column name in color_by='{color_by}'. Please make sure, that this"
+            + "column name is correct and one of the visible columns."
+        )
 
     ambigious_columns = [k for k, v in Counter(df[columns].columns).items() if v > 1]
     if ambigious_columns:

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -253,7 +253,7 @@ def parallel_coordinate_plot_parameters(
 
         parameter_type = df[column].dtype.name
         if parameter_type.startswith("float") or parameter_type.startswith("int"):
-            # Handling floats and integers as same, vecause unfortunately it's hard to
+            # Handling floats and integers the same, because unfortunately it's hard to
             # use integers only for ticks and still be robust regarding a large range
             # of values.
             coordinate["values"] = df[column]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.4.2"
+version = "4.4.3"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -412,3 +412,17 @@ def test_parallel_coordinate_plot_parameters_raise_on_ambigious_column_names():
     # Don't raise if duplicate column but not selected for plotting
     fig = parallel_coordinate_plot_parameters(evaluations, columns=["A", "B"])
     assert isinstance(fig, Figure)
+
+
+def test_parallel_coordinate_plot_parameters_raise_on_color_by_not_in_columns():
+    evaluations = [
+        Evaluation(objectives={"loss": 0.3}, configuration={"p1": 0.1, "hidden": 0.2})
+    ]
+    with pytest.raises(ValueError, match="hidden"):
+        parallel_coordinate_plot_parameters(
+            evaluations,
+            columns=["loss", "p1"],
+            color_by="hidden",
+        )
+    with pytest.raises(ValueError, match="not_existing"):
+        parallel_coordinate_plot_parameters(evaluations, color_by="not_existing")

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -331,18 +331,22 @@ def test_parallel_coordinate_plot_parameters():
         Evaluation(
             configuration={"float": 1.23, "int": 3, "bool": True, "categorical": "A"},
             objectives={"loss": 0.9, "score": 800},
+            settings={"fidelity": 0.3},
         ),
         Evaluation(
             configuration={"float": 9.23, "int": 15, "bool": False, "categorical": "B"},
             objectives={"loss": 0.3, "score": 900},
+            settings={"fidelity": 0.66},
         ),
         Evaluation(
             configuration={"float": 4.3, "int": 7, "bool": True, "categorical": "C"},
-            objectives={"loss": 0.1, "score": 700},
+            objectives={"loss": 0.1, "score": 1000},
+            settings={"fidelity": 1.0},
         ),
         Evaluation(
             configuration={"float": 4.3, "int": 7, "bool": True, "categorical": "C"},
             objectives={"loss": None, "score": 900},
+            settings={"fidelity": 1},
         ),
     ]
 
@@ -353,7 +357,7 @@ def test_parallel_coordinate_plot_parameters():
     assert isinstance(fig, Figure)
 
     fig = parallel_coordinate_plot_parameters(
-        evaluations, columns=["float", "int", "loss"]
+        evaluations, columns=["int", "float", "loss"]
     )
     assert isinstance(fig, Figure)
 

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -330,15 +330,19 @@ def test_parallel_coordinate_plot_parameters():
     evaluations = [
         Evaluation(
             configuration={"float": 1.23, "int": 3, "bool": True, "categorical": "A"},
-            objectives={"loss": 0.9, "score": 9001},
+            objectives={"loss": 0.9, "score": 800},
         ),
         Evaluation(
             configuration={"float": 9.23, "int": 15, "bool": False, "categorical": "B"},
-            objectives={"loss": 0.3, "score": 9001},
+            objectives={"loss": 0.3, "score": 900},
         ),
         Evaluation(
             configuration={"float": 4.3, "int": 7, "bool": True, "categorical": "C"},
-            objectives={"loss": 0.1, "score": 9001},
+            objectives={"loss": 0.1, "score": 700},
+        ),
+        Evaluation(
+            configuration={"float": 4.3, "int": 7, "bool": True, "categorical": "C"},
+            objectives={"loss": None, "score": 900},
         ),
     ]
     fig = parallel_coordinate_plot_parameters(evaluations, Objective("loss", False))

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -348,6 +348,9 @@ def test_parallel_coordinate_plot_parameters():
     fig = parallel_coordinate_plot_parameters(evaluations, Objective("loss", False))
     assert isinstance(fig, Figure)
 
+    fig = parallel_coordinate_plot_parameters(evaluations)
+    assert isinstance(fig, Figure)
+
 
 def test_parallel_coordinate_plot_parameters_raise_on_no_succesful_evals():
     with pytest.raises(NoSuccessfulEvaluationsError):

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -345,10 +345,21 @@ def test_parallel_coordinate_plot_parameters():
             objectives={"loss": None, "score": 900},
         ),
     ]
-    fig = parallel_coordinate_plot_parameters(evaluations, Objective("loss", False))
-    assert isinstance(fig, Figure)
 
     fig = parallel_coordinate_plot_parameters(evaluations)
+    assert isinstance(fig, Figure)
+
+    fig = parallel_coordinate_plot_parameters(evaluations, color_by="loss")
+    assert isinstance(fig, Figure)
+
+    fig = parallel_coordinate_plot_parameters(
+        evaluations, columns=["float", "int", "loss"]
+    )
+    assert isinstance(fig, Figure)
+
+    fig = parallel_coordinate_plot_parameters(
+        evaluations, columns=["float", "int", "score"], color_by="score"
+    )
     assert isinstance(fig, Figure)
 
 


### PR DESCRIPTION
Did that during my train ride as one way to introspect the evaluation results in a higher dimensional search space with a [parallel coordinates plot](https://plotly.com/python/parallel-coordinates-plot/).

Unfortunately, I can't upload an image here (proxy?), but you can debug into the the unit test and and do a `fig.show()` there, which also gives a better impression about the interactivity.

Known issues we might want to tackle in the future:
- Ordering of ordinal parameter values is not ensured
- Axis of Integer parameters might still show axis ticks on fractional positions 