### PR TITLE
Feature/default test for fixed parameters

### DIFF
--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -44,7 +44,11 @@ def _initialize_optimizer(
 
 
 def optimize_single_parameter_sequentially_for_n_max_evaluations(
-    optimizer_class, optimizer_kwargs: dict, n_max_evaluations: int = 20
+    optimizer_class: Union[
+        Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
+    ],
+    optimizer_kwargs: dict,
+    n_max_evaluations: int = 20,
 ) -> bool:
     """[summary]
 
@@ -101,7 +105,12 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     return True
 
 
-def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) -> bool:
+def is_deterministic_with_fixed_seed(
+    optimizer_class: Union[
+        Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
+    ],
+    optimizer_kwargs: dict,
+) -> bool:
     """Check if optimizer is deterministic.
 
     Repeatedly initialize the optimizer with the same parameter space and a fixed seed,
@@ -111,7 +120,7 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
 
     Args:
         optimizer_class: Optimizer to test.
-        optimizer_kwargs: Expected to contain additional arguments for initializating
+        optimizer_kwargs: Expected to contain additional arguments for initializing
             the optimizer. (`search_space` and `objective(s)` are set automatically
             by the test.)
 
@@ -139,17 +148,22 @@ def is_deterministic_with_fixed_seed(optimizer_class, optimizer_kwargs: dict) ->
     return True
 
 
-def handles_reporting_evaluations_list(optimizer_class, optimizer_kwargs: dict) -> bool:
-    """Check if optimizer's report method can process an iterable of evalutions.
+def handles_reporting_evaluations_list(
+    optimizer_class: Union[
+        Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
+    ],
+    optimizer_kwargs: dict,
+) -> bool:
+    """Check if optimizer's report method can process an iterable of evaluations.
 
-    All optimizers should be able to allow reporting batches of evalutions. It's up to
+    All optimizers should be able to allow reporting batches of evaluations. It's up to
     the optimizer's implementation, if evaluations in a batch are processed
     one by one like if they were reported individually, or if a batch is handled
     differently.
 
     Args:
         optimizer_class: Optimizer to test.
-        optimizer_kwargs: Expected to contain additional arguments for initializating
+        optimizer_kwargs: Expected to contain additional arguments for initializing
             the optimizer. (`search_space` and `objective(s)` are set automatically
             by the test.)
 
@@ -173,7 +187,10 @@ def handles_reporting_evaluations_list(optimizer_class, optimizer_kwargs: dict) 
 
 
 def raises_evaluation_error_when_reporting_unknown_objective(
-    optimizer_class, optimizer_kwargs: dict
+    optimizer_class: Union[
+        Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
+    ],
+    optimizer_kwargs: dict,
 ) -> bool:
     """Check if optimizer's report method raises exception in case objective is unknown.
 
@@ -182,7 +199,7 @@ def raises_evaluation_error_when_reporting_unknown_objective(
 
     Args:
         optimizer_class: Optimizer to test.
-        optimizer_kwargs: Expected to contain additional arguments for initializating
+        optimizer_kwargs: Expected to contain additional arguments for initializing
             the optimizer. (`search_space` and `objective(s)` are set automatically
             by the test.)
 
@@ -226,6 +243,18 @@ def respects_fixed_parameter(
     ],
     optimizer_kwargs: dict,
 ):
+    """Check if optimizer's generated evaluation specifications contain the values
+    a parameter in the search space was fixed to.
+
+    Args:
+        optimizer_class: Optimizer to test.
+        optimizer_kwargs: Expected to contain additional arguments for initializing
+            the optimizer. (`search_space` and `objective(s)` are set automatically
+            by the test.)
+
+    Returns:
+        `True` if the test is passed.
+    """
     space = ps.ParameterSpace()
     space.add(ps.ContinuousParameter("my_fixed_param", (-10.0, 200.0)))
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -26,7 +26,7 @@ def _initialize_optimizer(
     space: Optional[ps.ParameterSpace] = None,
     seed=42,
 ) -> Optimizer:
-    if not space:
+    if space is None:
         space = ps.ParameterSpace()
         space.add(ps.IntegerParameter("p1", bounds=[1, 32], transformation="log"))
         space.add(ps.ContinuousParameter("p2", [-2, 2]))

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -259,7 +259,7 @@ def respects_fixed_parameter(
     space.add(ps.ContinuousParameter("my_fixed_param", (-10.0, 200.0)))
 
     fixed_value = 1.0
-    space.fix(my_fixed_param=1.0)
+    space.fix(my_fixed_param=fixed_value)
 
     for _ in range(5):
         opt = _initialize_optimizer(

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -257,20 +257,23 @@ def respects_fixed_parameter(
     """
     space = ps.ParameterSpace()
     space.add(ps.ContinuousParameter("my_fixed_param", (-10.0, 200.0)))
+    space.add(ps.ContinuousParameter("x", (-2.0, 2.0)))
 
     fixed_value = 1.0
     space.fix(my_fixed_param=fixed_value)
-
+    opt = _initialize_optimizer(
+        optimizer_class,
+        optimizer_kwargs,
+        objective=Objective("loss", False),
+        objectives=[Objective("loss", False)],
+        space=space,
+    )
     for _ in range(5):
-        opt = _initialize_optimizer(
-            optimizer_class,
-            optimizer_kwargs,
-            objective=Objective("loss", False),
-            objectives=[Objective("loss", False)],
-            space=space,
-        )
         es = opt.generate_evaluation_specification()
         assert es.configuration["my_fixed_param"] == fixed_value
+        opt.report(
+            es.create_evaluation(objectives={"loss": es.configuration["x"] ** 2})
+        )
 
     return True
 

--- a/tests/optimizers/bohb_test.py
+++ b/tests/optimizers/bohb_test.py
@@ -18,7 +18,7 @@ from blackboxopt.optimizers.testing import ALL_REFERENCE_TESTS
 
 @pytest.mark.parametrize("reference_test", ALL_REFERENCE_TESTS)
 def test_all_reference_tests(reference_test):
-    reference_test(BOHB, dict(min_fidelity=0.2, max_fidelity=1, num_iterations=1))
+    reference_test(BOHB, dict(min_fidelity=0.2, max_fidelity=1, num_iterations=5))
 
 
 def test_sequential():

--- a/tests/optimizers/hyperband_test.py
+++ b/tests/optimizers/hyperband_test.py
@@ -17,7 +17,7 @@ from blackboxopt.optimizers.testing import ALL_REFERENCE_TESTS
 def test_all_reference_tests(reference_test):
     reference_test(
         Hyperband,
-        dict(min_fidelity=0.2, max_fidelity=1, num_iterations=1),
+        dict(min_fidelity=0.2, max_fidelity=1, num_iterations=5),
     )
 
 


### PR DESCRIPTION
We noticed for custom optimizer implementations that it could make sense to ensure that they respect fixed parameters, so this PR introduces a reference test that helps spot deviations from that expected behaviour.

I also added missing type hints and fixed docstring typos in the reference tests - if you'd like to de-clutter the diff, consider looking at the individual commits one by one, they are almost nicely curated (the one to spot the odd one out gets a drink :smile:).