### PR TITLE
Fix parallel coordinate plot breaking in case of non-hashable parameter values

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.4.4"
+__version__ = "4.4.5"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -280,7 +280,9 @@ def parallel_coordinate_plot_parameters(
             # Encode categorical values to integers. Unfortunately, ordinal parameters
             # loose there ordering, as there is no information about the order in the
             # evaluations.
-            df[column] = df[column].astype("category")
+            # The string conversion is necessary for unhashable entries, e.g. of
+            # type List, which can't be casted to categories.
+            df[column] = df[column].astype(str).astype("category")
             categories = df[column].cat.categories.to_list()
             encoded_categories = list(range(len(categories)))
             df[column].cat.categories = encoded_categories

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.4.4"
+version = "4.4.5"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -426,3 +426,13 @@ def test_parallel_coordinate_plot_parameters_raise_on_color_by_not_in_columns():
         )
     with pytest.raises(ValueError, match="not_existing"):
         parallel_coordinate_plot_parameters(evaluations, color_by="not_existing")
+
+
+def test_parallel_coordinate_plot_parameters_with_unhashable_parameters():
+    evaluations = [
+        Evaluation(objectives={"loss": 0.3}, configuration={"p1": [1, 2, 3]})
+    ]
+    fig = parallel_coordinate_plot_parameters(
+        evaluations, columns=["loss", "p1"], color_by="p1"
+    )
+    assert isinstance(fig, Figure)


### PR DESCRIPTION
I notice that issue, when I tried to visualize the run with a parameterspace containing:

```python
ps.CategoricalParameter("p1", (None, [0,1,2], [3,2,4]))
```

While this also can be avoided on user side by choosing tuples instead of list, the proposed change of converting to string first makes the visualization robust for such cases without any downsides (I think?).

Signed-off-by: Buech Holger <holger.buech@de.bosch.com>