### PR TITLE
display single scatter plot instead of scatter matrix for two objectives

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.4.6"
+__version__ = "4.4.7"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -178,22 +178,28 @@ def multi_objective_visualization(
     # Create hover template and list of corresponding dataframe column names
     hover_template, hover_data_columns = create_hover_information(hover_sections)
 
-    fig = px.scatter_matrix(
-        df,
-        dimensions=[o.name for o in objectives],
+    fig_kwargs = dict(
+        data_frame=df,
         color="pareto efficient",
         color_discrete_map={
             False: QUALITATIVE_COLORS[5],
             True: QUALITATIVE_COLORS[2],
         },
-        title="[BBO] Scatter matrix of multi objective values",
         custom_data=hover_data_columns,
+        title="[BBO] Multi-objective pairwise scatter plot",
     )
-    fig.update_traces(
-        diagonal_visible=False,
+    traces_kwargs: Dict[str, Union[str, dict, bool]] = dict(
         hovertemplate=hover_template,
         marker=dict(line=dict(width=1, color="white")),
     )
+
+    if len(objectives) == 2:
+        fig = px.scatter(**fig_kwargs, x=objectives[0].name, y=objectives[1].name)
+    else:
+        fig = px.scatter_matrix(**fig_kwargs, dimensions=[o.name for o in objectives])
+        traces_kwargs["diagonal_visible"] = False
+
+    fig.update_traces(**traces_kwargs)
     return fig
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.4.6"
+version = "4.4.7"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -128,7 +128,7 @@ def test_int_none_float_loss_mix_does_not_break_viz():
     viz.cdf_durations()
 
 
-def test_multi_objective_visualization():
+def test_multi_objective_visualization_two_objectives():
     evaluations = [
         Evaluation(
             objectives={"loss_1": 0.5 * i, "loss_2": -0.5 * i},
@@ -147,6 +147,32 @@ def test_multi_objective_visualization():
     multi_objective_visualization(
         evaluations=evaluations,
         objectives=(Objective("loss_1", False), Objective("loss_2", False)),
+    )
+
+
+def test_multi_objective_visualization_more_than_two_objectives():
+    evaluations = [
+        Evaluation(
+            objectives={"loss_1": 0.5 * i, "loss_2": -0.5 * i, "score": -(i**2)},
+            configuration={
+                "mlp_shape": 0.14054333845130684,
+                "optimizer": "Adam",
+                "batch_size": 160,
+            },
+            optimizer_info={"rung": -1},
+            user_info={},
+            settings={"fidelity": 2.5},
+        )
+        for i in range(5)
+    ]
+
+    multi_objective_visualization(
+        evaluations=evaluations,
+        objectives=(
+            Objective("loss_1", False),
+            Objective("loss_2", False),
+            Objective("score", True),
+        ),
     )
 
 


### PR DESCRIPTION
Before this PR, when visualizing pairwise objective scatter plots with two objectives, we showed the same scatter plot matrix like with more than two objectives even though it is not necessary. This PR now shows a simple scatter plot in the two objectives case to save space and be less confusing visually due to displaying the same plot twice, mirrored, in a matrix diagonal.

Signed-off-by: Grossberger Lukas (CR/PJ-AI-R32) <Lukas.Grossberger@de.bosch.com>