### PR TITLE
add filter pareto front from eval util

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.4.7"
+__version__ = "4.5.0"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/utils.py
+++ b/blackboxopt/visualizations/utils.py
@@ -12,6 +12,9 @@ import numpy as np
 import blackboxopt
 from blackboxopt import Evaluation, Objective
 
+# For backwards compatibility reasons
+from blackboxopt.utils import mask_pareto_efficient
+
 
 def get_t0(evaluations: List[Evaluation]):
     return min([e.created_unixtime for e in evaluations])
@@ -170,27 +173,6 @@ def add_plotly_buttons_for_logscale(fig):
     ]
 
     fig.update_layout(updatemenus=updatemenus)
-
-
-def mask_pareto_efficient(costs: np.ndarray):
-    """For a given array of objective values where lower values are considered better
-    and the dimensions are samples x objectives, return a mask that is `True` for all
-    pareto efficient values.
-
-    NOTE: The result marks multiple occurrences of the same point all as pareto
-    efficient.
-    """
-    is_efficient = np.ones(costs.shape[0], dtype=bool)
-    for i, c in enumerate(costs):
-        if not is_efficient[i]:
-            continue
-
-        # Keep any point with a lower cost or when they are the same
-        efficient = np.any(costs[is_efficient] < c, axis=1)
-        duplicates = np.all(costs[is_efficient] == c, axis=1)
-        is_efficient[is_efficient] = np.logical_or(efficient, duplicates)
-
-    return is_efficient
 
 
 def patch_plotly_io_to_html(method: Callable) -> Callable:

--- a/blackboxopt/visualizations/utils.py
+++ b/blackboxopt/visualizations/utils.py
@@ -12,7 +12,7 @@ import numpy as np
 import blackboxopt
 from blackboxopt import Evaluation, Objective
 
-# For backwards compatibility reasons
+# For backwards compatibility; TODO: remove with next major release
 from blackboxopt.utils import mask_pareto_efficient
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.4.7"
+version = "4.5.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,8 +6,12 @@
 import numpy as np
 import pytest
 
-from blackboxopt import Objective
-from blackboxopt.utils import get_loss_vector
+from blackboxopt import Evaluation, Objective
+from blackboxopt.utils import (
+    filter_pareto_efficient,
+    get_loss_vector,
+    mask_pareto_efficient,
+)
 
 
 @pytest.mark.parametrize(
@@ -42,3 +46,46 @@ def test_get_loss_vector_with_custom_none_replacement():
         none_replacement=float("Inf"),
     )
     np.testing.assert_array_equal(loss_vector, np.array(expected))
+
+
+def test_mask_pareto_efficient():
+    evals = np.array(
+        [
+            [0.0, 1.0],
+            [1.1, 0.1],
+            [0.0, 1.0],
+            [1.0, 0.0],
+            [3.1, 1.1],
+            [0.1, 1.0],
+            [0.0, 1.1],
+            [-1.0, 2.0],
+        ]
+    )
+    pareto_efficient = mask_pareto_efficient(evals)
+    assert len(pareto_efficient) == evals.shape[0]
+    assert pareto_efficient[0]
+    assert not pareto_efficient[1]
+    assert pareto_efficient[2]
+    assert pareto_efficient[3]
+    assert not pareto_efficient[4]
+    assert not pareto_efficient[5]
+    assert not pareto_efficient[6]
+    assert pareto_efficient[7]
+
+
+def test_filter_pareto_efficient():
+    evals = [
+        Evaluation(configuration={"i": 0}, objectives={"loss": 0.0, "score": -1.0}),
+        Evaluation(configuration={"i": 1}, objectives={"loss": 1.1, "score": -0.1}),
+        Evaluation(configuration={"i": 2}, objectives={"loss": 0.0, "score": -1.0}),
+        Evaluation(configuration={"i": 3}, objectives={"loss": 1.0, "score": 0.0}),
+        Evaluation(configuration={"i": 4}, objectives={"loss": 3.1, "score": -1.1}),
+        Evaluation(configuration={"i": 5}, objectives={"loss": 0.1, "score": -1.0}),
+        Evaluation(configuration={"i": 6}, objectives={"loss": 0.0, "score": -1.1}),
+        Evaluation(configuration={"i": 7}, objectives={"loss": -1.0, "score": -2.0}),
+    ]
+    pareto_efficient = filter_pareto_efficient(
+        evals, [Objective("loss", False), Objective("score", True)]
+    )
+    assert len(pareto_efficient) == 4
+    assert set([0, 2, 3, 7]) == set([e.configuration["i"] for e in pareto_efficient])

--- a/tests/visualization_test.py
+++ b/tests/visualization_test.py
@@ -11,7 +11,6 @@ from plotly.graph_objs._figure import Figure
 from blackboxopt import Evaluation, EvaluationSpecification, Objective
 from blackboxopt.visualizations.utils import (
     get_incumbent_objective_over_time_single_fidelity,
-    mask_pareto_efficient,
 )
 from blackboxopt.visualizations.visualizer import (
     NoSuccessfulEvaluationsError,
@@ -241,31 +240,6 @@ def test_multi_objective_visualization_without_fidelities():
     multi_objective_visualization(
         evaluations, (Objective("loss", False), Objective("score", True))
     )
-
-
-def test_mask_pareto_efficient():
-    evals = np.array(
-        [
-            [0.0, 1.0],
-            [1.1, 0.1],
-            [0.0, 1.0],
-            [1.0, 0.0],
-            [3.1, 1.1],
-            [0.1, 1.0],
-            [0.0, 1.1],
-            [-1.0, 2.0],
-        ]
-    )
-    pareto_efficient = mask_pareto_efficient(evals)
-    assert len(pareto_efficient) == evals.shape[0]
-    assert pareto_efficient[0]
-    assert not pareto_efficient[1]
-    assert pareto_efficient[2]
-    assert pareto_efficient[3]
-    assert not pareto_efficient[4]
-    assert not pareto_efficient[5]
-    assert not pareto_efficient[6]
-    assert pareto_efficient[7]
 
 
 def test_prepare_for_multi_objective_visualization_handles_score_objectives():


### PR DESCRIPTION
The time has come and we benefit from a function that just takes a list of evaluations and filters out the pareto front, in addition to / building on the previous implementation of the loss matrix based mask.

Signed-off-by: Grossberger Lukas (CR/AIR2.2) <Lukas.Grossberger@de.bosch.com>