### PR TITLE
add conditional space reference test

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.5.1"
+__version__ = "4.6.0"
 
 from parameterspace import ParameterSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.5.1"
+version = "4.6.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/optimizers/random_search_test.py
+++ b/tests/optimizers/random_search_test.py
@@ -10,7 +10,7 @@ from blackboxopt import Objective, OptimizationComplete
 from blackboxopt.optimizers.random_search import RandomSearch
 from blackboxopt.optimizers.testing import ALL_REFERENCE_TESTS
 
-MAX_STEPS = 5
+MAX_STEPS = 15
 
 SPACE = ps.ParameterSpace()
 SPACE.add(ps.ContinuousParameter("p1", [0, 1]))


### PR DESCRIPTION
This PR adds a test to the default compatibility test suite that contains a condition in the search space, i.e. has a hierarchical search space. This change requires all optimizers that test against the default tests to support conditional spaces.

Signed-off-by: Grossberger Lukas (CR/AIR2.2) <Lukas.Grossberger@de.bosch.com>