### PR TITLE
Add additional reference test for determinism

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.0"
+__version__ = "4.6.1"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -51,7 +51,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     ],
     optimizer_kwargs: dict,
     n_max_evaluations: int = 20,
-) -> bool:
+):
     """[summary]
 
     Args:
@@ -104,15 +104,13 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
         evaluation = eval_spec.create_evaluation(objectives=evaluation_result)
         optimizer.report(evaluation)
 
-    return True
-
 
 def is_deterministic_with_fixed_seed_and_larger_space(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if optimizer is deterministic.
 
     Repeatedly initialize the optimizer with the same parameter space and a fixed seed,
@@ -150,7 +148,6 @@ def is_deterministic_with_fixed_seed_and_larger_space(
         final_configurations.append(es2.configuration.copy())
 
     assert final_configurations[0] == final_configurations[1]
-    return True
 
 
 def is_deterministic_when_reporting_shuffled_evaluations(
@@ -158,7 +155,7 @@ def is_deterministic_when_reporting_shuffled_evaluations(
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if determinism isn't affected by the order of initially reported data.
 
     Repeatedly initialize the optimizer with the same parameter space and a fixed seed.
@@ -228,15 +225,13 @@ def is_deterministic_when_reporting_shuffled_evaluations(
     assert initial_configs_run_0 != initial_configs_run_1
     assert configs_run_0 == configs_run_1
 
-    return True
-
 
 def handles_reporting_evaluations_list(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if optimizer's report method can process an iterable of evaluations.
 
     All optimizers should be able to allow reporting batches of evaluations. It's up to
@@ -266,7 +261,6 @@ def handles_reporting_evaluations_list(
         evaluations.append(evaluation)
 
     opt.report(evaluations)
-    return True
 
 
 def raises_evaluation_error_when_reporting_unknown_objective(
@@ -274,7 +268,7 @@ def raises_evaluation_error_when_reporting_unknown_objective(
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if optimizer's report method raises exception in case objective is unknown.
 
     Also make sure that the faulty evaluations (and only those) are included in the
@@ -317,15 +311,13 @@ def raises_evaluation_error_when_reporting_unknown_objective(
         assert len(invalid_evaluations) == 1
         assert evaluation_2 in invalid_evaluations
 
-    return True
-
 
 def respects_fixed_parameter(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if optimizer's generated evaluation specifications contain the values
     a parameter in the search space was fixed to.
 
@@ -358,15 +350,13 @@ def respects_fixed_parameter(
             es.create_evaluation(objectives={"loss": es.configuration["x"] ** 2})
         )
 
-    return True
-
 
 def handles_conditional_space(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
     optimizer_kwargs: dict,
-) -> bool:
+):
     """Check if optimizer handles conditional i.e. hierarchical search spaces.
 
     Args:
@@ -398,8 +388,6 @@ def handles_conditional_space(
         es = opt.generate_evaluation_specification()
         dummy_loss = es.configuration.get("momentum", 1.0) * es.configuration["lr"] ** 2
         opt.report(es.create_evaluation({"loss": dummy_loss}))
-
-    return True
 
 
 ALL_REFERENCE_TESTS = [

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -209,7 +209,7 @@ def is_deterministic_when_reporting_shuffled_evaluations(
         opt.report(evaluations)
 
         # Start optimizing
-        for _ in range(8):
+        for _ in range(5):
             es = opt.generate_evaluation_specification()
             opt.report(
                 es.create_evaluation(objectives={"loss": _run_experiment_1d(es)})

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -197,7 +197,7 @@ def is_deterministic_when_reporting_shuffled_evaluations(
             seed=0,
         )
 
-        # Report initial data in differenht order
+        # Report initial data in different order
         eval_specs = [opt.generate_evaluation_specification() for _ in range(8)]
         run["inital_evaluations"] = [
             es.create_evaluation(objectives={"loss": _run_experiment_1d(es)})
@@ -253,6 +253,7 @@ def handles_reporting_evaluations_list(
         optimizer_kwargs,
         objective=Objective("loss", False),
         objectives=[Objective("loss", False)],
+        seed=42,
     )
     evaluations = []
     for _ in range(3):

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -30,9 +30,9 @@ def _initialize_optimizer(
 ) -> Optimizer:
     if space is None:
         space = ps.ParameterSpace()
-        space.add(ps.IntegerParameter("p1", bounds=[1, 32], transformation="log"))
-        space.add(ps.ContinuousParameter("p2", [-2, 2]))
-        space.add(ps.ContinuousParameter("p3", [0, 1]))
+        space.add(ps.IntegerParameter("p1", bounds=(1, 32), transformation="log"))
+        space.add(ps.ContinuousParameter("p2", (-2, 2)))
+        space.add(ps.ContinuousParameter("p3", (0, 1)))
         space.add(ps.CategoricalParameter("p4", [True, False]))
         space.add(ps.OrdinalParameter("p5", ("small", "medium", "large")))
 
@@ -179,7 +179,7 @@ def is_deterministic_when_reporting_shuffled_evaluations(
     """
 
     space = ps.ParameterSpace()
-    space.add(ps.ContinuousParameter("p1", [0, 1]))
+    space.add(ps.ContinuousParameter("p1", (0, 1)))
 
     def _run_experiment_1d(es):
         x = es.configuration["p1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.6.0"
+version = "4.6.1"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Proposal for a test to verify deterministic behavior when reporting a list of evaluations at once (here as initial data), even if the order of the list varies. 

Currently all optimizer pass the test (**EDIT:** except BOHB), but still I'm not 100% sure: is this _always_ the _desired_ behavior? Or are there cases, where we expect and desire different optimizer behavior depending on the order?

Signed-off-by: Buech Holger <holger.buech@de.bosch.com>