### PR TITLE
Add utility function to derministically sort list of evaluations

### DIFF
--- a/architecture_decision_records/deterministic-sorting-of-evaluations.md
+++ b/architecture_decision_records/deterministic-sorting-of-evaluations.md
@@ -1,0 +1,40 @@
+**In the context of** ensuring deterministic behavior of optimizers, **facing the need**
+to sort batches of evaluations before processing them, **we decided** to use the md5
+hash of the pickled representation of relevant evaluation attributes as key for sorting
+**and against** simpler approaches **to achieve** a good sorting performance,
+**accepting** a slightly more complex implementation involving object serialization in
+between.
+
+_Additional background:_
+
+The function in question, `blackboxopt.utils.sort_evaluations()`, is required to sort a
+`List[Evaluation]` by only considering optimization relevant attributes and disregarding
+all others that might be subject to change/randomness (e.g. timestamps).
+
+Additionally, sorting the dictionary keys (denoted `(sorted)` in the comparison below)
+is necessary for being robust against changes in the order of the reported parameters.
+
+Sorting performance depends a lot on the amount of parameters and the number of
+elements. In a quick test different methods were used to sort a list of 1000 evaluations
+with 20 parameters. The time reported is total seconds for sorting the same list 1000
+times (or the mean milliseconds per sort):
+
+```
+json (sorted)
+32.07862658100203
+
+md5 of json (sorted)
+29.56752566599971
+
+md5 of pickle
+2.9176704900019104
+
+md5 of pickle of (sorted) <-- pull requested implementation
+8.36911787000281
+
+md5 of str
+21.312109268001223
+
+str
+19.841941792001307
+```

--- a/blackboxopt/utils.py
+++ b/blackboxopt/utils.py
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
+import pickle
 from itertools import compress
 from typing import Dict, List, Optional, Sequence
 
@@ -80,3 +82,20 @@ def filter_pareto_efficient(
     pareto_efficient_mask = mask_pareto_efficient(losses)
 
     return list(compress(evaluations, pareto_efficient_mask))
+
+
+def sort_evaluations(evaluations: List[Evaluation]) -> List[Evaluation]:
+    return sorted(
+        evaluations,
+        key=lambda e: hashlib.md5(
+            pickle.dumps(
+                [
+                    sorted(e.configuration.items()),
+                    sorted(e.objectives.items()),
+                    sorted(e.settings.items()),
+                    sorted(e.constraints.items()) if e.constraints else {},
+                    sorted(e.context.items()) if e.context else {},
+                ]
+            )
+        ).hexdigest(),
+    )

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -98,44 +98,44 @@ def test_filter_pareto_efficient():
     "evals",
     (
         [  # Different parameter values
-            Evaluation(configuration={"i": 3, "c": "A"}, objectives={"l": 0.0}),
-            Evaluation(configuration={"i": 2, "c": "B"}, objectives={"l": 0.0}),
-            Evaluation(configuration={"i": 1, "c": "C"}, objectives={"l": 0.0}),
+            Evaluation(configuration={"p1": 3, "p2": "A"}, objectives={"o": 0.0}),
+            Evaluation(configuration={"p1": 2, "p2": "B"}, objectives={"o": 0.0}),
+            Evaluation(configuration={"p1": 1, "p2": "C"}, objectives={"o": 0.0}),
         ],
         [  # Different objective values
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.0}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.3}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.2}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0.0}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0.3}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0.2}),
         ],
         [  # Different parameters
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.0}),
-            Evaluation(configuration={"i": 1, "j": 2}, objectives={"l": 0.0}),
-            Evaluation(configuration={"k": 1}, objectives={"l": 0.0}),
+            Evaluation(configuration={"p1": 1}, objectives={"o": 0.0}),
+            Evaluation(configuration={"p1": 1, "p2": 2}, objectives={"o": 0.0}),
+            Evaluation(configuration={"p3": 1}, objectives={"o": 0.0}),
         ],
         [  # Different multi objective values
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.0, "m": 0.1}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.0, "m": 0.2}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0.0, "m": 0.3}),
+            Evaluation(configuration={"p": 1}, objectives={"o1": 0.0, "o2": 0.1}),
+            Evaluation(configuration={"p": 1}, objectives={"o1": 0.0, "o2": 0.2}),
+            Evaluation(configuration={"p": 1}, objectives={"o1": 0.0, "o2": 0.3}),
         ],
         [  # Different context
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, context={"c": 1}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, context={"c": 2}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, context={"c": 3}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, context={"c": 1}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, context={"c": 2}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, context={"c": 3}),
         ],
         [  # Different settings
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, settings={"s": 1}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, settings={"s": 2}),
-            Evaluation(configuration={"i": 1}, objectives={"l": 0}, settings={"s": 3}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, settings={"s": 1}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, settings={"s": 2}),
+            Evaluation(configuration={"p": 1}, objectives={"o": 0}, settings={"s": 3}),
         ],
         [  # Different constraints
             Evaluation(
-                configuration={"i": 1}, objectives={"l": 0}, constraints={"c": 1}
+                configuration={"p": 1}, objectives={"o": 0}, constraints={"c": 1}
             ),
             Evaluation(
-                configuration={"i": 1}, objectives={"l": 0}, constraints={"c": 2}
+                configuration={"p": 1}, objectives={"o": 0}, constraints={"c": 2}
             ),
             Evaluation(
-                configuration={"i": 1}, objectives={"l": 0}, constraints={"c": 3}
+                configuration={"p": 1}, objectives={"o": 0}, constraints={"c": 3}
             ),
         ],
     ),


### PR DESCRIPTION
This doesn't introduce any functional changes yet, but prepares fixing determinism issues in #64.

The goal is to provide a function that's able to deterministically sort a `List[Evaluation]` by _only_ considering optimization relevant attributes, disregarding all others that might be subject to change/randomness (e.g. timestamps). 

Sorting the dictionary keys is the only option I found for being robust also against changes in the order of parameters, too. 

Performance depends a lot on the amount of parameters and the number of elements. In a quick test I tried different methods using a list of 1000 evaluations with 20 parameters.  The time is total seconds for sorting 1000 times (or the mean milliseconds per sort):

```
json sorted 
32.07862658100203

md5 of json sorted
29.56752566599971

md5 of pickle
2.9176704900019104

md5 of pickle of sorted <-- pull requested implementation
8.36911787000281

md5 of str
21.312109268001223

str
19.841941792001307
```

What do you think?

Also: I was unsure if we should include `optimizer_info` into the sorting. To me it seems like it's mostly used/set internally by the optimizer, but I'm not 100% certain.

Signed-off-by: Buech Holger <holger.buech@de.bosch.com>