### PR TITLE
Feature/fix determinism in bohbs config sampler

### DIFF
--- a/blackboxopt/optimizers/bohb.py
+++ b/blackboxopt/optimizers/bohb.py
@@ -107,6 +107,7 @@ class BOHB(StagedIterationOptimizer):
             random_fraction=random_fraction,
             bandwidth_factor=bandwidth_factor,
             min_bandwidth=min_bandwidth,
+            seed=seed,
         )
 
         super().__init__(

--- a/blackboxopt/optimizers/staged/bohb.py
+++ b/blackboxopt/optimizers/staged/bohb.py
@@ -55,8 +55,7 @@ def sample_around_values(
     Returns:
         Numerical representation of a configuration close to the provided datum.
     """
-    if rng is None:
-        rng = np.random.default_rng()
+    rng = np.random.default_rng(rng)
 
     vector = []
     for m, bw, t in zip(datum, bandwidths, vartypes):
@@ -151,8 +150,7 @@ def impute_conditional_data(
         Numerical representation where all NaNs have been replaced with observed values
         or prior samples.
     """
-    if rng is None:
-        rng = np.random.default_rng()
+    rng = np.random.default_rng(rng)
 
     return_array = np.empty_like(array)
 
@@ -322,7 +320,7 @@ class Sampler(StagedIterationConfigurationSampler):
                 cached_rng_state = None
                 if self.seed:
                     cached_rng_state = np.random.get_state()
-                    np.random.seed(self.seed + 1)
+                    np.random.seed(self.seed + i)
 
                 val = minimize_me(vector)
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -27,7 +27,7 @@ def _initialize_optimizer(
     seed=42,
 ) -> Optimizer:
     if space is None:
-        space = ps.ParameterSpace()
+        space = ps.ParameterSpace(seed=seed)
         space.add(ps.IntegerParameter("p1", bounds=[1, 32], transformation="log"))
         space.add(ps.ContinuousParameter("p2", [-2, 2]))
         space.add(ps.ContinuousParameter("p3", [0, 1]))
@@ -105,7 +105,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     return True
 
 
-def is_deterministic_with_fixed_seed(
+def is_deterministic_with_fixed_seed_and_mixed_space(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
@@ -117,6 +117,8 @@ def is_deterministic_with_fixed_seed(
     get an evaluation specification, report a placeholder result and get another
     evaluation specification. The configuration of all final evaluation specifications
     should be equal.
+
+    This tests covers multiple parameter types by using a mixed search space.
 
     Args:
         optimizer_class: Optimizer to test.
@@ -143,6 +145,55 @@ def is_deterministic_with_fixed_seed(
         es2 = opt.generate_evaluation_specification()
 
         final_configurations.append(es2.configuration.copy())
+
+    assert final_configurations[0] == final_configurations[1]
+    return True
+
+
+def is_deterministic_with_fixed_seed_and_multiple_evaluations(
+    optimizer_class: Union[
+        Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
+    ],
+    optimizer_kwargs: dict,
+) -> bool:
+    """Check if optimizer is deterministic, even after multiple evaluations.
+
+    Repeatedly initialize the optimizer with the same parameter space and a fixed seed,
+    then report a number of evaluations. The configuration of all final evaluations
+    should be equal.
+
+    By doing multiple evaluations, this tests covers effects that become visible after
+    a while, e.g. only after stages got completed in staged iteration samplers.
+
+    Args:
+        optimizer_class: Optimizer to test.
+        optimizer_kwargs: Expected to contain additional arguments for initializing
+            the optimizer. (`search_space` and `objective(s)` are set automatically
+            by the test.)
+
+    Returns:
+        `True` if the test is passed.
+    """
+    final_configurations = []
+    for _ in range(2):
+        space = ps.ParameterSpace(seed=42)
+        space.add(ps.ContinuousParameter("p1", [0, 1]))
+
+        opt = _initialize_optimizer(
+            optimizer_class,
+            optimizer_kwargs,
+            objective=Objective("loss", False),
+            objectives=[Objective("loss", False)],
+            space=space,
+            seed=42,
+        )
+
+        for _ in range(15):
+            es = opt.generate_evaluation_specification()
+            evaluation = es.create_evaluation(objectives={"loss": 0.42})
+            opt.report(evaluation)
+
+        final_configurations.append(evaluation.configuration.copy())
 
     assert final_configurations[0] == final_configurations[1]
     return True
@@ -321,7 +372,8 @@ def handles_conditional_space(
 
 ALL_REFERENCE_TESTS = [
     optimize_single_parameter_sequentially_for_n_max_evaluations,
-    is_deterministic_with_fixed_seed,
+    is_deterministic_with_fixed_seed_and_mixed_space,
+    is_deterministic_with_fixed_seed_and_multiple_evaluations,
     handles_reporting_evaluations_list,
     raises_evaluation_error_when_reporting_unknown_objective,
     respects_fixed_parameter,

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -27,7 +27,7 @@ def _initialize_optimizer(
     seed=42,
 ) -> Optimizer:
     if space is None:
-        space = ps.ParameterSpace(seed=seed)
+        space = ps.ParameterSpace()
         space.add(ps.IntegerParameter("p1", bounds=[1, 32], transformation="log"))
         space.add(ps.ContinuousParameter("p2", [-2, 2]))
         space.add(ps.ContinuousParameter("p3", [0, 1]))
@@ -105,7 +105,7 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
     return True
 
 
-def is_deterministic_with_fixed_seed_and_mixed_space(
+def is_deterministic_with_fixed_seed_and_larger_space(
     optimizer_class: Union[
         Type[SingleObjectiveOptimizer], Type[MultiObjectiveOptimizer]
     ],
@@ -372,7 +372,7 @@ def handles_conditional_space(
 
 ALL_REFERENCE_TESTS = [
     optimize_single_parameter_sequentially_for_n_max_evaluations,
-    is_deterministic_with_fixed_seed_and_mixed_space,
+    is_deterministic_with_fixed_seed_and_larger_space,
     is_deterministic_with_fixed_seed_and_multiple_evaluations,
     handles_reporting_evaluations_list,
     raises_evaluation_error_when_reporting_unknown_objective,

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -188,9 +188,9 @@ def is_deterministic_with_fixed_seed_and_multiple_evaluations(
             seed=42,
         )
 
-        for _ in range(15):
+        for i in range(15):
             es = opt.generate_evaluation_specification()
-            evaluation = es.create_evaluation(objectives={"loss": 0.42})
+            evaluation = es.create_evaluation(objectives={"loss": i})
             opt.report(evaluation)
 
         final_configurations.append(evaluation.configuration.copy())


### PR DESCRIPTION
While working on #64 and #65 I noticed, that BOHB's config sampler wasn't yet deterministic. This wasn't noticed so far, because the effect only becomes visible after multiple evaluations, and also seems to depend on the search space. (With our default mixed space for testing, there was no effect within 15 evaluations, while with a more simple 1D space, the proposed configurations started to diverge slightly after ~8 evaluations).

This PR proposes:

1. An additional reference test to capture this issue (which BOHB fails) 
2. A way to seed the BOHBs config sampler (to make BOHB pass the new test)

**Notes:** 
Unfortunately, `statsmodels` seems to still rely on global `numpy.random.seed()`, and the evaluation of the KDE estimators PDF depends on that. I tried to increase the thread safeness by (re-)seeding very close to the actual call. Also I cache the global state and revert it after our seeding to avoid undesired side effects (e.g. if a user depends on a certain global numpy seed). [This section still not looks really clean to me](https://github.com/boschresearch/blackboxopt/pull/66/files#diff-b0243323422e6ec3d5d243dff46be689c0a769ce03499e41ca7411ed8579fd17R311-R331), so if you have any better ideas, that'd be great. :-)