### PR TITLE
Extend deterministic ref test to compare five configurations.

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.6.2"
+__version__ = "4.6.3"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -151,6 +151,7 @@ def is_deterministic_with_fixed_seed_and_larger_space(
 
             run_configs.append(evaluation.configuration)
 
+    assert len(run_0_configs) == n_evaluations
     assert run_0_configs == run_1_configs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.6.2"
+version = "4.6.3"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Signed-off-by: Anna Eivazi <anna.eivazi@de.bosch.com>

This PR proposes to increase number of configurations (requested sequentially) for checking optimizer determinism, which makes test more reliable and less dependent on number of initial sampling strategies or optimizer's specific heuristics for initial proposals. 