### PR TITLE
Reshape fantasized model only for ExactGP

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.7.1"
+__version__ = "4.7.2"
 
 from parameterspace import ParameterSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.7.1"
+version = "4.7.2"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Small addition that allows for models that are not subclasses of ExactGP when using `SingleObjectiveBOTorchOptimizer`

Signed-off-by: Lucia Reeb [lucia.reeb@de.bosch.com](mailto:lucia.reeb@de.bosch.com)