### PR TITLE
fix model update in gpbo, add nan filtering

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.8.4"
+__version__ = "4.8.5"
 
 from parameterspace import ParameterSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.8.4"
+version = "4.8.5"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Despite conditioning the model on data when reporting for the GPBO optimizer, we never stored the updated model. Thus, we also missed the lack of support for handling `None` objectives, which is also now there.