### PR TITLE
get __version__ from importlib instead of hard coding

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,6 @@
-__version__ = "4.8.4"
+import importlib
+
+__version__ = importlib.metadata.version("blackboxopt")
 
 from parameterspace import ParameterSpace
 


### PR DESCRIPTION
Because I forgot to manually update the `__version__` in accordance with `pyproject.toml` every single time for the last couple PRs, let's try this instead :relaxed: 