### PR TITLE
add parameterspace versions 0.8.* as compatible

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.9.0"
+__version__ = "4.9.1"
 
 from parameterspace import ParameterSpace
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -788,7 +788,7 @@ test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "parameterspace"
-version = "0.7.22"
+version = "0.8.0"
 description = "Parametrized hierarchical spaces with flexible priors and transformations."
 category = "main"
 optional = false
@@ -1456,7 +1456,7 @@ visualization = ["plotly", "scipy", "pandas"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.12"
-content-hash = "156f629e08e95bd1e952d9ad5f430941d27cfed03ba7bc295f4efbd28579098e"
+content-hash = "e4283c8ff54864e5ad9adef959edd7430a08afc7b3e4f332549dbfee90cee144"
 
 [metadata.files]
 astroid = [
@@ -2059,8 +2059,8 @@ pandas = [
     {file = "pandas-1.5.3.tar.gz", hash = "sha256:74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1"},
 ]
 parameterspace = [
-    {file = "parameterspace-0.7.22-py3-none-any.whl", hash = "sha256:4a4dc8e48b2f2d372bb19fc890d1d276fcf125d401f7877f8c973399f0808626"},
-    {file = "parameterspace-0.7.22.tar.gz", hash = "sha256:c3da685d5f30ce0f0695b800fd5ae68ded1aa815c88d2c9745ee3339bc76f889"},
+    {file = "parameterspace-0.8.0-py3-none-any.whl", hash = "sha256:6e4c59cc90c73582f40a637e034009a6fa8fcbe77537cf9a96a9bf3185a001a3"},
+    {file = "parameterspace-0.8.0.tar.gz", hash = "sha256:b4e50d1b72c6c6af64d8a54f5e57276f2cc7a97ba46bcddd45367584b40214f3"},
 ]
 partd = [
     {file = "partd-1.3.0-py3-none-any.whl", hash = "sha256:6393a0c898a0ad945728e34e52de0df3ae295c5aff2e2926ba7cc3c60a734a15"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.9.0"
+version = "4.9.1"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.12"
-parameterspace = "^0.7.2"
+parameterspace = ">=0.7.2,<0.9"
 numpy = {version = "^1.22.0", optional = true}
 plotly = {version = "^5.10.0", optional = true}
 scipy = {version = "^1.6.0", optional = true}


### PR DESCRIPTION
This PR allows to use both, the previous parameterspace version as well as the most recent one that now requires parameter names to be valid python variable names, so that we can use them together but nobody is forced to switch yet. We can make this tighter again when we rely on specific new parameterspace features that the older versions don't have.