### PR TITLE
Feature/objective wise none replacement

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.10.0"
+__version__ = "4.11.0"
 
 from parameterspace import ParameterSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.10.0"
+version = "4.11.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -18,22 +18,34 @@ from blackboxopt.utils import (
 
 
 @pytest.mark.parametrize(
-    "known,reported,expected",
+    "known,reported,none_replacement,expected",
     [
         (
             [Objective("score", True), Objective("loss", False)],
             {"loss": 2.0, "score": 1.0},
+            float("NaN"),
             [-1.0, 2.0],
         ),
         (
             [Objective("score", True), Objective("loss", False)],
             {"loss": 2.0, "score": None},
-            [np.nan, 2.0],
+            float("NaN"),
+            [float("NaN"), 2.0],
+        ),
+        (
+            [Objective("score", True), Objective("loss", False)],
+            {"loss": None, "score": None},
+            [float("-inf"), float("inf")],
+            [float("-inf"), float("inf")],
         ),
     ],
 )
-def test_get_loss_vector(known, reported, expected):
-    loss_vector = get_loss_vector(known_objectives=known, reported_objectives=reported)
+def test_get_loss_vector(known, reported, none_replacement, expected):
+    loss_vector = get_loss_vector(
+        known_objectives=known,
+        reported_objectives=reported,
+        none_replacement=none_replacement,
+    )
     np.testing.assert_array_equal(loss_vector, np.array(expected))
 
 


### PR DESCRIPTION
If one wants to use infinity as the numerical loss representation for `None` objective values, the direction of the objective matters. This PR introduces backward compatible support for individual none representation values per objective.

An alternative that I decided against due to the lack of generality and transparency to the call context is detecting `inf` and adding a sign according to the objective direction in the loss vector function.