### PR TITLE
Fix constraints in reference Test

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.13.0"
+__version__ = "4.13.1"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -84,11 +84,12 @@ def optimize_single_parameter_sequentially_for_n_max_evaluations(
 
     if issubclass(optimizer_class, MultiObjectiveOptimizer):
         evaluation = eval_spec.create_evaluation(
-            objectives={"loss": None, "score": None}
+            objectives={"loss": None, "score": None},
+            constraints={"constraint": 10.0},
         )
     else:
         evaluation = eval_spec.create_evaluation(
-            objectives={"loss": None}, constraints={"constraint": None}
+            objectives={"loss": None}, constraints={"constraint": 10.0}
         )
     optimizer.report(evaluation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.13.0"
+version = "4.13.1"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
This PR adds valid constraint values to the first evaluation in the reference test `opimize_single_parameter_sequentially_for_n_max_evaluations`. The behavior for the previous value `None` was not defined.