### PR TITLE
add utils to save and load a study json

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.13.2"
+__version__ = "4.14.0"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/utils.py
+++ b/blackboxopt/utils.py
@@ -113,10 +113,15 @@ def save_study_as_json(
     overwrite: bool = False,
 ):
     """Save space, objectives and evaluations as json at `json_file_path`."""
-    if Path(json_file_path).exists() and not overwrite:
-        raise ValueError(f"{json_file_path} exists and overwrite is False")
+    _file_path = Path(json_file_path)
+    if not _file_path.parent.exists():
+        raise IOError(
+            f"The parent directory for {_file_path} does not exist, please create it."
+        )
+    if _file_path.exists() and not overwrite:
+        raise IOError(f"{_file_path} exists and overwrite is False")
 
-    with open(json_file_path, "w", encoding="UTF-8") as fh:
+    with open(_file_path, "w", encoding="UTF-8") as fh:
         json.dump(
             {
                 "search_space": search_space.to_dict(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.13.2"
+version = "4.14.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -14,8 +14,10 @@ from blackboxopt.utils import (
     filter_pareto_efficient,
     get_loss_vector,
     load_study_from_pickle,
+    load_study_from_json,
     mask_pareto_efficient,
     save_study_as_pickle,
+    save_study_as_json,
     sort_evaluations,
 )
 
@@ -216,3 +218,26 @@ def test_save_and_load_study_pickle_fails_on_missing_output_directory():
             evaluations=[],
             pickle_file_path=pickle_file_path,
         )
+
+
+def test_save_and_load_study_json(tmp_path):
+    tmp_file = tmp_path / "out.json"
+
+    search_space = ps.ParameterSpace()
+    objectives = [Objective("loss", False), Objective("score", True)]
+    evaluations = [
+        Evaluation(configuration={"p1": 1.0}, objectives={"loss": 1.0, "score": 3.0}),
+        Evaluation(configuration={"p1": 2.0}, objectives={"loss": 0.1, "score": 2.0}),
+        Evaluation(configuration={"p1": 3.0}, objectives={"loss": 0.0, "score": 1.0}),
+    ]
+    save_study_as_json(search_space, objectives, evaluations, tmp_file)
+
+    # Check that default overwrite=False causes ValueError on existing file
+    with pytest.raises(ValueError):
+        save_study_as_json(search_space, objectives, evaluations, tmp_file)
+
+    loaded_study = load_study_from_json(tmp_file)
+
+    assert loaded_study[0] == search_space
+    assert loaded_study[1] == objectives
+    assert loaded_study[2] == evaluations

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -13,11 +13,11 @@ from blackboxopt import Evaluation, Objective
 from blackboxopt.utils import (
     filter_pareto_efficient,
     get_loss_vector,
-    load_study_from_pickle,
     load_study_from_json,
+    load_study_from_pickle,
     mask_pareto_efficient,
-    save_study_as_pickle,
     save_study_as_json,
+    save_study_as_pickle,
     sort_evaluations,
 )
 
@@ -234,16 +234,26 @@ def test_save_and_load_study_json(tmp_path):
     save_study_as_json(search_space, objectives, evaluations, tmp_file)
 
     # Check that default overwrite=False causes ValueError on existing file
-    with pytest.raises(ValueError):
+    with pytest.raises(IOError):
         save_study_as_json(search_space, objectives, evaluations, tmp_file)
 
     loaded_study = load_study_from_json(tmp_file)
 
     assert loaded_study[1] == objectives
     assert loaded_study[2] == evaluations
-
     for _ in range(128):
         assert search_space.sample() == loaded_study[0].sample()
+
+
+def test_save_and_load_study_json_fails_on_missing_output_directory():
+    json_file_path = "/this/directory/does/not/exist/jsons/out.json"
+    with pytest.raises(IOError, match=json_file_path):
+        save_study_as_json(
+            search_space=ps.ParameterSpace(),
+            objectives=[],
+            evaluations=[],
+            json_file_path=json_file_path,
+        )
 
 
 def test_save_and_load_study_json_fails_with_complex_type_in_evaluation(tmp_path):


### PR DESCRIPTION
Before, one would need to take care of storing evaluations with the search space they came from and the matching objectives individually. Now, there are two utility functions for saving and loading to and from JSON respectively.

There is also a corresponding follow up at `feature/save-and-load-study-pickle` in case we like this pattern for JSON.