### PR TITLE
update checkout action v2 -> v3

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: python:3.8-slim
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install poetry
@@ -33,7 +33,7 @@ jobs:
         python-version: ["python:3.8", "python:3.9", "python:3.10", "python:3.11"]
     container: ${{ matrix.python-version }}-slim
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install poetry
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: python:3.8-slim
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip install poetry
@@ -62,7 +62,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # fetch all branches, incl. gh-pages
       - uses: actions/setup-python@v2


### PR DESCRIPTION
This PR aims to resolve the warnings:
> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.