### PR TITLE
add on release published as ci/cd trigger

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
     - main
+  release:
+    types: [published]
 jobs:
   lint:
     runs-on: ubuntu-20.04

--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.15.0"
+__version__ = "4.15.1"
 
 from parameterspace import ParameterSpace
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.15.0"
+version = "4.15.1"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
It seems like creating releases (and with that a tag) via the GitHub web ui doesn't trigger our CI/CD pipeline anymore. This PR should fix that.