### PR TITLE
update fixed seed reference test to use two objectives in mo case

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.11.0"
+__version__ = "4.12.0"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/optimizers/testing.py
+++ b/blackboxopt/optimizers/testing.py
@@ -150,15 +150,20 @@ def is_deterministic_with_fixed_seed_and_larger_space(
             optimizer_class,
             optimizer_kwargs,
             objective=Objective("loss", False),
-            objectives=[Objective("loss", False)],
+            objectives=[Objective("loss", False), Objective("score", True)],
             seed=seed or 42,
         )
 
         for i in range(n_evaluations):
             es = opt.generate_evaluation_specification()
+
+            objectives = {"loss": losses[i]}
+            if isinstance(opt, MultiObjectiveOptimizer):
+                objectives["score"] = -1.0 * losses[i] ** 2
             evaluation = es.create_evaluation(
-                objectives={"loss": losses[i]}, constraints={"constraint": 10.0}
+                objectives=objectives, constraints={"constraint": 10.0}
             )
+
             opt.report(evaluation)
 
             run_configs.append(evaluation.configuration)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "4.11.0"
+version = "4.12.0"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
@aeivazi, I still had this PR in the pipeline from back in March but am not 100% confident if the original motivation still exists - can you help fill in the gaps, whether this is still something we'd like to tackle. I remember we wanted to not expect all multi objective optimizers to successfully handle one objective and thus switch to two objectives in our reference test.