### PR TITLE
add pre eval callback and stringify user info for logging

### DIFF
--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import logging
+import pprint
 import time
 from typing import Any, Callable, List, Optional, Union
 
@@ -89,7 +89,7 @@ def run_optimization_loop(
 
             logger.info(
                 "The optimizer proposed the following evaluation specification:\n%s",
-                json.dumps(evaluation_specification.to_dict(), indent=2),
+                pprint.pformat(evaluation_specification.to_dict(), compact=True),
             )
             if pre_evaluation_callback:
                 pre_evaluation_callback(evaluation_specification)
@@ -104,15 +104,7 @@ def run_optimization_loop(
 
             logger.info(
                 "Reporting the following evaluation result to the optimizer:\n%s",
-                json.dumps(
-                    {
-                        # Stringify the user_info because it is not guaranteed to be
-                        # json serializable
-                        k: str(v) if k == "user_info" else v
-                        for k, v in evaluation.to_dict().items()
-                    },
-                    indent=2,
-                ),
+                pprint.pformat(evaluation.to_dict(), compact=True),
             )
             if post_evaluation_callback:
                 post_evaluation_callback(evaluation)

--- a/blackboxopt/optimization_loops/sequential.py
+++ b/blackboxopt/optimization_loops/sequential.py
@@ -91,7 +91,7 @@ def run_optimization_loop(
                 "The optimizer proposed the following evaluation specification:\n%s",
                 json.dumps(evaluation_specification.to_dict(), indent=2),
             )
-            if pre_evaluation_callback is not None:
+            if pre_evaluation_callback:
                 pre_evaluation_callback(evaluation_specification)
 
             evaluation = evaluation_function_wrapper(
@@ -114,7 +114,7 @@ def run_optimization_loop(
                     indent=2,
                 ),
             )
-            if post_evaluation_callback is not None:
+            if post_evaluation_callback:
                 post_evaluation_callback(evaluation)
 
             optimizer.report(evaluation)

--- a/tests/optimization_loops/sequential_test.py
+++ b/tests/optimization_loops/sequential_test.py
@@ -58,3 +58,19 @@ def test_post_evaluation_callback():
 
     assert len(evaluations) == len(evaluations_from_callback)
     assert evaluations == evaluations_from_callback
+
+
+def test_pre_evaluation_callback():
+    eval_specs_from_callback = []
+
+    def callback(e: Evaluation):
+        eval_specs_from_callback.append(e)
+
+    evaluations = run_optimization_loop(
+        RandomSearch(testing.SPACE, [Objective("loss", False)], max_steps=10),
+        lambda e: e.create_evaluation(objectives={"loss": 0.0}),
+        pre_evaluation_callback=callback,
+    )
+
+    assert len(evaluations) == len(eval_specs_from_callback)
+    assert [e.get_specification() for e in evaluations] == eval_specs_from_callback


### PR DESCRIPTION
* Close #97 by casting the `user_info` to string before dumping it to JSON for logging
* Add pre-evaluation callback
* Add reference to evaluation function wrapper in docstring for more transparency about `catch_exceptions_from_evaluation_function` argument