### PR TITLE
add pipefail for tests in action (closes #111)

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -48,7 +48,10 @@ jobs:
           poetry install --extras "all"
       - name: Run tests
         if: always()
-        run: poetry run pytest --cov=blackboxopt tests | sed -n '/ -----------/,$p' > coverage.txt
+        # pipefail ensures that this step still fails when pytest fails
+        run: |
+          set -o pipefail
+          poetry run pytest --cov=blackboxopt tests | sed -n '/ -----------/,$p' > coverage.txt
       # Note, this overrides the coverage file for each python version again.
       # If different coverage is expected per python version, log separate artifacts.
       - name: Upload coverage

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           set -o pipefail
           poetry run pytest --cov=blackboxopt tests | sed -n '/ -----------/,$p' > coverage.txt
+        shell: bash
       # Note, this overrides the coverage file for each python version again.
       # If different coverage is expected per python version, log separate artifacts.
       - name: Upload coverage

--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "4.15.1"
+__version__ = "5.0.0"
 
 from parameterspace import ParameterSpace
 


### PR DESCRIPTION
Seems like failing tests didn't cause our GH Actions workflow to fail anymore ever since I added the pipe for the coverage report (see two commits in this PR).