### PR TITLE
remove redundant non dominated sorting in hypervolume vis

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -16,7 +16,6 @@ import plotly.graph_objects as go
 import plotly.io._html
 import scipy.stats as sps
 from pymoo.indicators.hv import HV
-from pymoo.util.nds.efficient_non_dominated_sort import efficient_non_dominated_sort
 
 from blackboxopt import Evaluation, Objective
 from blackboxopt.utils import get_loss_vector
@@ -210,6 +209,7 @@ def compute_hypervolume(
     objectives: Sequence[Objective],
     reference_point: List[float],
 ) -> float:
+    hv = HV(reference_point, nds=True)
     losses = np.array(
         [
             get_loss_vector(
@@ -218,12 +218,7 @@ def compute_hypervolume(
             for e in evaluations
         ]
     )
-    pareto_front_idx = efficient_non_dominated_sort(losses)[0]
-    pareto_front = losses[pareto_front_idx]
-
-    hv = HV(reference_point)
-
-    return hv(pareto_front)
+    return hv(losses)
 
 
 def hypervolume_over_iterations(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "5.0.0"
+version = "5.0.1"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"


### PR DESCRIPTION
Turns out, the pymoo hypervolume indicator by default does ensure non dominated sorting based filtering of the input loss matrix to only contain the pareto front. Accordingly, our manual additional pareto front filtering is gone now and I also made the default `nds=True` explicit in the indicator initialization. From anecdotal evidence, this yields in a speed up of ~10x.

We can likely speed the sequential hypervolume computation up even further with a custom implementation based on our pareto front util function along with switching to `nds=False`, but that is for a separate PR.