### PR TITLE
relax pymoo bound to 0.5 using backward compat hypervolume api

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.0.1"
+__version__ = "5.0.2"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/visualizations/visualizer.py
+++ b/blackboxopt/visualizations/visualizer.py
@@ -15,7 +15,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import plotly.io._html
 import scipy.stats as sps
-from pymoo.indicators.hv import HV
+from pymoo.indicators.hv import Hypervolume
 
 from blackboxopt import Evaluation, Objective
 from blackboxopt.utils import get_loss_vector
@@ -209,7 +209,7 @@ def compute_hypervolume(
     objectives: Sequence[Objective],
     reference_point: List[float],
 ) -> float:
-    hv = HV(reference_point, nds=True)
+    hv = Hypervolume(reference_point, nds=True)
     losses = np.array(
         [
             get_loss_vector(
@@ -218,7 +218,7 @@ def compute_hypervolume(
             for e in evaluations
         ]
     )
-    return hv(losses)
+    return hv.do(losses)
 
 
 def hypervolume_over_iterations(

--- a/poetry.lock
+++ b/poetry.lock
@@ -2680,4 +2680,4 @@ visualization = ["pandas", "plotly", "pymoo", "scipy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "e484dcd94a5cc27a26be4c79b817a922509f85d3c97bc5eaf7ce965c862588cc"
+content-hash = "8ed8b8b4e17295aea6a0869065b34d38c5caa762a8e3b27f5d4b58c1980c2ceb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blackboxopt"
-version = "5.0.1"
+version = "5.0.2"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 repository = "https://github.com/boschresearch/blackboxopt"
@@ -33,7 +33,7 @@ pandas = {version = "^1.2.4", optional = true}
 sympy = {version = "^1.12", optional = true}
 torch = {version = ">=1.12", optional = true, source = "pytorch-cpu"}
 botorch = {version = "^0.7.1", optional = true}
-pymoo = {version = "^0.6.0.1", optional = true}
+pymoo = {version = ">=0.5,<1.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
While it's nice that we can just re-use pymoos hypervolume implementation, this introduces a rather specific optimization related dependency for our visualization extra. To allow for compatibility with a wider range of pymoo versions, courtesy of pymoo's diligence regarding backward compatibility, this PR switches to an older (hypervolume) indicator api that is still supported and thus allows compatibility with pymoo 0.5 as well as the most recent 0.6.