### PR TITLE
add fidelities calculator for staged iteration optimizers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,49 @@ implementation.
 BOHB is provided as a cleaner replacement of the former implementation in
 [HpBandSter](https://github.com/automl/HpBandSter).
 
+#### Fidelities for BOHB & Hyperband
+
+You can calculate the fidelity schedule resulting from these parameters:
+
+<script>
+function calculateFidelitiesBOHB() {
+    const min_fidelity = document.getElementById('minFidelityBOHB').value;
+    const max_fidelity = document.getElementById('maxFidelityBOHB').value;
+    const eta = document.getElementById('etaBOHB').value;
+
+    const max_num_stages = 1 + Math.floor(
+        Math.log(max_fidelity / min_fidelity) / Math.log(eta)
+    );
+    const num_configs_first_stage = Math.ceil(Math.pow(eta, max_num_stages - 1));
+    const num_configs_per_stage = Array.from({ length: max_num_stages }, (_, i) =>
+        Math.floor(num_configs_first_stage / Math.pow(eta, i))
+    );
+    const fidelities_per_stage = Array.from({ length: max_num_stages }, (_, i) =>
+        max_fidelity / Math.pow(eta, max_num_stages - 1 - i)
+    );
+
+    document.getElementById('fidelitiesBOHB').innerHTML = `Fidelities: ${fidelities_per_stage}`;
+}
+</script>
+<table>
+    <tr>
+        <td>min_fidelity</td>
+        <td><input type="text" id="minFidelityBOHB"></td>
+    </tr>
+    <tr>
+        <td>max_fidelity</td>
+        <td><input type="text" id="maxFidelityBOHB"></td>
+    </tr>
+    <tr>
+        <td>eta</td>
+        <td><input type="text" id="etaBOHB"></td>
+    </tr>
+    <tr>
+        <td></td><td><button onclick="calculateFidelitiesBOHB();">Submit</button></td>
+    </tr>
+</table>
+<p id="fidelitiesBOHB"></p>
+
 ### Optimization Loops
 
 As part of the `blackboxopt.optimization_loops` module compatible implementations for


### PR DESCRIPTION
Whenever I speak with folks using BOHB or Hyperband, they struggle to grasp the connection between the fidelity related settings and how they translate to the actual fidelity levels that are evaluated. This little JavaScript calculator in our docs should help with that, I hope.
I was contemplating whether to go for a table or flexbox with div containers, and concluded that the form is so small, that mobile device optimization is not necessary, wdyt?