### PR TITLE
update actions to avoid coverage report on release

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -57,6 +57,7 @@ jobs:
           name: coverage
           path: .coverage.${{ matrix.python-version }}
   report:
+    if: github.event_name != 'release'
     needs: [test]
     runs-on: ubuntu-20.04
     permissions:


### PR DESCRIPTION
This should fix the actions error we saw in our previous release: https://github.com/boschresearch/blackboxopt/actions/runs/7916729063