### PR TITLE
fix predict model based best on empty model

### DIFF
--- a/blackboxopt/__init__.py
+++ b/blackboxopt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "5.3.6"
+__version__ = "5.3.7"
 
 from parameterspace import ParameterSpace
 

--- a/blackboxopt/optimizers/botorch_utils.py
+++ b/blackboxopt/optimizers/botorch_utils.py
@@ -214,6 +214,11 @@ def predict_model_based_best(
     ):
         return None
 
+    # The type signature does not suggest this is possible, but our test demonstrates
+    # the issue: test_predict_model_based_best_returns_none_for_empty_model
+    if isinstance(model.train_inputs, tuple) and model.train_inputs[0].numel() == 0:
+        return None
+
     def posterior_mean(x):
         # function to be optimized: posterior mean
         # scipy's minimize expects the following interface:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blackboxopt"
-version = "5.3.6"
+version = "5.3.7"
 description = "A common interface for blackbox optimization algorithms along with useful helpers like parallel optimization loops, analysis and visualization scripts."
 readme = "README.md"
 authors = [{name = "Bosch Center for AI, Robert Bosch GmbH"}]

--- a/tests/optimizers/botorch_utils_test.py
+++ b/tests/optimizers/botorch_utils_test.py
@@ -7,6 +7,12 @@ import numpy as np
 import pytest
 import torch
 
+import torch
+import parameterspace as ps
+from botorch.models import SingleTaskGP
+from blackboxopt import Objective
+from blackboxopt.optimizers.botorch_utils import predict_model_based_best
+
 from blackboxopt import ConstraintsError, Evaluation, Objective
 from blackboxopt.optimizers.botorch_base import (
     filter_y_nans,
@@ -250,3 +256,20 @@ def test_filter_y_nans():
     y_multi_batch = torch.tensor([[[0.4], [0.4]], [[0.8], [np.nan]]])
     with pytest.raises(ValueError, match="Multiple batches"):
         filter_y_nans(x_multi_batch, y_multi_batch)
+
+def test_predict_model_based_best_returns_none_for_empty_model():
+     """predict_model_based_best should return None when the model has no training data,
+     i.e. no evaluations have been reported yet."""
+     search_space = ps.ParameterSpace()
+     search_space.add(ps.ContinuousParameter("x0", (0.0, 1.0)))
+ 
+     objective = Objective("loss", greater_is_better=False)
+ 
+     model = SingleTaskGP(
+         torch.empty(0, 1, dtype=torch.float64),
+         torch.empty(0, 1, dtype=torch.float64),
+         outcome_transform=None,
+     )
+ 
+     result = predict_model_based_best(model, search_space, objective, torch.float64)
+     assert result is None

--- a/tests/optimizers/botorch_utils_test.py
+++ b/tests/optimizers/botorch_utils_test.py
@@ -257,19 +257,20 @@ def test_filter_y_nans():
     with pytest.raises(ValueError, match="Multiple batches"):
         filter_y_nans(x_multi_batch, y_multi_batch)
 
+
 def test_predict_model_based_best_returns_none_for_empty_model():
-     """predict_model_based_best should return None when the model has no training data,
-     i.e. no evaluations have been reported yet."""
-     search_space = ps.ParameterSpace()
-     search_space.add(ps.ContinuousParameter("x0", (0.0, 1.0)))
- 
-     objective = Objective("loss", greater_is_better=False)
- 
-     model = SingleTaskGP(
-         torch.empty(0, 1, dtype=torch.float64),
-         torch.empty(0, 1, dtype=torch.float64),
-         outcome_transform=None,
-     )
- 
-     result = predict_model_based_best(model, search_space, objective, torch.float64)
-     assert result is None
+    """predict_model_based_best should return None when the model has no training data,
+    i.e. no evaluations have been reported yet."""
+    search_space = ps.ParameterSpace()
+    search_space.add(ps.ContinuousParameter("x0", (0.0, 1.0)))
+
+    objective = Objective("loss", greater_is_better=False)
+
+    model = SingleTaskGP(
+        torch.empty(0, 1, dtype=torch.float64),
+        torch.empty(0, 1, dtype=torch.float64),
+        outcome_transform=None,
+    )
+
+    result = predict_model_based_best(model, search_space, objective, torch.float64)
+    assert result is None

--- a/tests/optimizers/botorch_utils_test.py
+++ b/tests/optimizers/botorch_utils_test.py
@@ -4,14 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import parameterspace as ps
 import pytest
 import torch
-
-import torch
-import parameterspace as ps
 from botorch.models import SingleTaskGP
-from blackboxopt import Objective
-from blackboxopt.optimizers.botorch_utils import predict_model_based_best
 
 from blackboxopt import ConstraintsError, Evaluation, Objective
 from blackboxopt.optimizers.botorch_base import (
@@ -19,6 +15,7 @@ from blackboxopt.optimizers.botorch_base import (
     impute_nans_with_constant,
     to_numerical,
 )
+from blackboxopt.optimizers.botorch_utils import predict_model_based_best
 
 from .conftest import constraint_name_1, constraint_name_2, objective_name
 

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "blackboxopt"
-version = "5.3.6"
+version = "5.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "parameterspace" },


### PR DESCRIPTION
Due to the recent botorch update we could run into an issue we didn't previously catch when trying to predict best with an empty model, so I added a test and fix for it.